### PR TITLE
feat(app): add Compose state and navigation foundation

### DIFF
--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/MainContract.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/MainContract.kt
@@ -1,0 +1,178 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.navigation3.runtime.NavKey
+import com.motionapps.sensorbox.core.preferences.AppPreferences
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+import com.motionapps.sensorservices.session.MeasurementSessionState
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class MainRoute : NavKey {
+    ONBOARDING,
+    RECORD,
+    ACTIVE_MEASUREMENT,
+    SENSOR_DETAILS,
+    SENSOR_PREVIEW,
+    SETUP,
+    SETTINGS,
+    LICENSES,
+    PRIVACY,
+}
+
+enum class MainMessage {
+    NONE,
+    PICK_AT_LEAST_ONE_SOURCE,
+    STORAGE_REQUIRED,
+    PERMISSION_REQUIRED,
+    MEASUREMENT_FAILED,
+}
+
+data class MainState(
+    val route: MainRoute = MainRoute.ONBOARDING,
+    val onboardingPage: Int = 0,
+    val sensors: List<SensorDescriptor> = emptyList(),
+    val wearSensors: List<SensorDescriptor> = emptyList(),
+    val detailsSensorType: Int? = null,
+    val selectedSensorIds: Set<Int> = emptySet(),
+    val includesGps: Boolean = false,
+    val selectedWearSensorIds: Set<Int> = emptySet(),
+    val wearIncludesGps: Boolean = false,
+    val customMeasurementName: String = "",
+    val measurementType: String = "ENDLESS",
+    val startDelaySeconds: Int = 0,
+    val durationSeconds: Int = 0,
+    val notes: String = "",
+    val alarmOffsets: String = "",
+    val activityRecognition: Boolean = false,
+    val activityRecognitionPeriodSeconds: Int = 30,
+    val significantMotion: Boolean = false,
+    val storagePath: String? = null,
+    val preferences: AppPreferences = AppPreferences(),
+    val hasLoadedPreferences: Boolean = false,
+    val session: MeasurementSessionState = MeasurementSessionState.Idle,
+    val elapsedSeconds: Long = 0,
+    val isWearConnected: Boolean = false,
+    val message: MainMessage = MainMessage.NONE,
+)
+
+sealed interface MainIntent {
+    data class Navigate(val route: MainRoute) : MainIntent
+    data class ToggleSensor(val sensorId: Int) : MainIntent
+    data class ToggleWearSensor(val sensorId: Int) : MainIntent
+    data class OpenSensorDetails(val sensorType: Int?) : MainIntent
+    data object ToggleGps : MainIntent
+    data object ToggleWearGps : MainIntent
+    data object AdvanceOnboarding : MainIntent
+    data object RetreatOnboarding : MainIntent
+    data object CompleteOnboarding : MainIntent
+    data object OpenPrivacyPolicy : MainIntent
+    data object OpenTermsOfUse : MainIntent
+    data object RequestBatteryOptimizationExemption : MainIntent
+    data object ShareDiagnosticsText : MainIntent
+    data object ShareDiagnosticsFile : MainIntent
+    data object ChooseStorage : MainIntent
+    data object OpenMeasurementSetup : MainIntent
+    data object ReturnToSensorSelection : MainIntent
+    data object StartMeasurement : MainIntent
+    data object StopMeasurement : MainIntent
+    data object ClearMessage : MainIntent
+    data class SetCustomMeasurementName(val value: String) : MainIntent
+    data class SetMeasurementType(val value: String) : MainIntent
+    data class SetStartDelay(val seconds: Int) : MainIntent
+    data class SetDuration(val seconds: Int) : MainIntent
+    data class SetNotes(val value: String) : MainIntent
+    data class SetAlarmOffsets(val value: String) : MainIntent
+    data class SetActivityRecognition(val enabled: Boolean) : MainIntent
+    data class SetActivityRecognitionPeriod(val seconds: Int) : MainIntent
+    data class SetSignificantMotion(val enabled: Boolean) : MainIntent
+    data class AddAnnotation(val text: String) : MainIntent
+    data class SetSamplingPeriod(val index: Int) : MainIntent
+    data class SetLowBatteryRestriction(val enabled: Boolean) : MainIntent
+    data class SetWakeLock(val enabled: Boolean) : MainIntent
+    data class SetKeepScreenAwake(val enabled: Boolean) : MainIntent
+    data class SetGpsInterval(val seconds: Int) : MainIntent
+    data class SetGpsDistance(val meters: Int) : MainIntent
+}
+
+sealed interface MainEffect {
+    data object PickStorageDirectory : MainEffect
+    data object OpenPrivacyPolicy : MainEffect
+    data object OpenTermsOfUse : MainEffect
+    data object RequestBatteryOptimizationExemption : MainEffect
+    data object ShareDiagnosticsText : MainEffect
+    data object ShareDiagnosticsFile : MainEffect
+    data class RequestPermissions(val permissions: Set<String>) : MainEffect
+}
+
+data class MainNext(val state: MainState, val effect: MainEffect? = null)
+
+object MainReducer {
+    fun reduce(state: MainState, intent: MainIntent): MainNext = when (intent) {
+        MainIntent.AdvanceOnboarding -> MainNext(state.copy(onboardingPage = state.onboardingPage + 1))
+        MainIntent.RetreatOnboarding -> MainNext(state.retreatOnboarding())
+        is MainIntent.OpenSensorDetails -> MainNext(state.openSensorDetails(intent.sensorType))
+        else -> reduceGeneralIntent(state, intent)
+    }
+
+    private fun reduceGeneralIntent(state: MainState, intent: MainIntent): MainNext = when (intent) {
+        MainIntent.ChooseStorage -> MainNext(state, MainEffect.PickStorageDirectory)
+        MainIntent.ClearMessage -> MainNext(state.copy(message = MainMessage.NONE))
+        MainIntent.OpenPrivacyPolicy -> MainNext(state, MainEffect.OpenPrivacyPolicy)
+        MainIntent.OpenTermsOfUse -> MainNext(state, MainEffect.OpenTermsOfUse)
+        MainIntent.RequestBatteryOptimizationExemption -> batteryOptimizationEffect(state)
+        MainIntent.ShareDiagnosticsText -> MainNext(state, MainEffect.ShareDiagnosticsText)
+        MainIntent.ShareDiagnosticsFile -> MainNext(state, MainEffect.ShareDiagnosticsFile)
+        MainIntent.OpenMeasurementSetup -> MainNext(state.openMeasurementSetup())
+        MainIntent.ReturnToSensorSelection -> MainNext(state.returnToSensorSelection())
+        else -> reduceSelectionIntent(state, intent)
+    }
+
+    private fun reduceSelectionIntent(state: MainState, intent: MainIntent): MainNext = when (intent) {
+        MainIntent.ToggleGps -> MainNext(state.copy(includesGps = !state.includesGps))
+        MainIntent.ToggleWearGps -> MainNext(state.copy(wearIncludesGps = !state.wearIncludesGps))
+        is MainIntent.Navigate -> MainNext(state.copy(route = intent.route))
+        is MainIntent.ToggleSensor -> MainNext(state.toggleSensor(intent.sensorId))
+        is MainIntent.ToggleWearSensor -> MainNext(state.toggleWearSensor(intent.sensorId))
+        else -> reduceConfigurationIntent(state, intent)
+    }
+
+    private fun reduceConfigurationIntent(state: MainState, intent: MainIntent): MainNext = when (intent) {
+        is MainIntent.SetCustomMeasurementName -> MainNext(state.copy(customMeasurementName = intent.value))
+        is MainIntent.SetMeasurementType -> MainNext(state.copy(measurementType = intent.value))
+        is MainIntent.SetStartDelay -> MainNext(state.copy(startDelaySeconds = intent.seconds.coerceAtLeast(0)))
+        is MainIntent.SetDuration -> MainNext(state.copy(durationSeconds = intent.seconds.coerceAtLeast(0)))
+        is MainIntent.SetNotes -> MainNext(state.copy(notes = intent.value))
+        is MainIntent.SetAlarmOffsets -> MainNext(state.copy(alarmOffsets = intent.value))
+        is MainIntent.SetActivityRecognition -> MainNext(state.copy(activityRecognition = intent.enabled))
+        is MainIntent.SetActivityRecognitionPeriod -> MainNext(state.withActivityPeriod(intent.seconds))
+        is MainIntent.SetSignificantMotion -> MainNext(state.copy(significantMotion = intent.enabled))
+        else -> MainNext(state)
+    }
+
+    private fun batteryOptimizationEffect(state: MainState) =
+        MainNext(state, MainEffect.RequestBatteryOptimizationExemption)
+
+    private fun MainState.retreatOnboarding() = copy(onboardingPage = (onboardingPage - 1).coerceAtLeast(0))
+
+    private fun MainState.openSensorDetails(sensorType: Int?) =
+        copy(route = MainRoute.SENSOR_DETAILS, detailsSensorType = sensorType)
+
+    private fun MainState.openMeasurementSetup() = copy(route = MainRoute.SETUP, message = MainMessage.NONE)
+
+    private fun MainState.returnToSensorSelection() = copy(route = MainRoute.RECORD, message = MainMessage.NONE)
+
+    private fun MainState.toggleSensor(sensorId: Int): MainState {
+        val updated = selectedSensorIds.toMutableSet()
+        if (!updated.add(sensorId)) updated.remove(sensorId)
+        return copy(selectedSensorIds = updated, message = MainMessage.NONE)
+    }
+
+    private fun MainState.toggleWearSensor(sensorId: Int): MainState {
+        val updated = selectedWearSensorIds.toMutableSet()
+        if (!updated.add(sensorId)) updated.remove(sensorId)
+        return copy(selectedWearSensorIds = updated, message = MainMessage.NONE)
+    }
+}
+
+private fun MainState.withActivityPeriod(seconds: Int) =
+    copy(activityRecognitionPeriodSeconds = seconds.coerceAtLeast(1))

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/MainViewModel.kt
@@ -1,0 +1,322 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.content.Intent
+import android.os.SystemClock
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.suspendFlatMap
+import com.motionapps.sensorbox.core.preferences.AppPreferencesIntent
+import com.motionapps.sensorbox.core.preferences.AppPreferencesRepository
+import com.motionapps.sensorbox.domain.measurement.DocumentStorageUseCase
+import com.motionapps.sensorbox.domain.measurement.MeasurementControlUseCase
+import com.motionapps.sensorbox.domain.measurement.MeasurementPermissionUseCase
+import com.motionapps.sensorbox.domain.measurement.MeasurementRequest
+import com.motionapps.sensorbox.domain.sensors.GetAvailableSensorsUseCase
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+import com.motionapps.sensorservices.session.MeasurementSessionState
+import com.motionapps.sensorservices.session.MeasurementSessionStore
+import com.motionapps.wearoslib.WearOsConstants.WEAR_APP_CAPABILITY
+import com.motionapps.wearoslib.WearOsConstants.WEAR_MESSAGE_PATH
+import com.motionapps.wearoslib.connectivity.ObserveWearCapabilityUseCase
+import com.motionapps.wearoslib.connectivity.SendWearMessageUseCase
+import com.motionapps.wearoslib.connectivity.WearConnection
+import com.motionapps.wearoslib.protocol.WearCommand
+import com.motionapps.wearoslib.protocol.WearCommandCodec
+import com.motionapps.wearoslib.protocol.WearSensorCatalogStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+@Suppress("TooManyFunctions")
+class MainViewModel @Inject constructor(
+    private val preferencesRepository: AppPreferencesRepository,
+    private val getAvailableSensors: GetAvailableSensorsUseCase,
+    private val documentStorage: DocumentStorageUseCase,
+    private val measurementPermissions: MeasurementPermissionUseCase,
+    private val measurementControl: MeasurementControlUseCase,
+    private val sessionStore: MeasurementSessionStore,
+    private val observeWearCapability: ObserveWearCapabilityUseCase,
+    private val sendWearMessage: SendWearMessageUseCase,
+    private val wearSensorCatalog: WearSensorCatalogStore,
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(initialState())
+    private val mutableEffects = Channel<MainEffect>(Channel.BUFFERED)
+    private var hasChosenInitialRoute = false
+    private var elapsedJob: Job? = null
+
+    val state: StateFlow<MainState> = mutableState.asStateFlow()
+    val effects = mutableEffects.receiveAsFlow()
+
+    init {
+        observePreferences()
+        observeMeasurementSession()
+        observeWearConnection()
+        observeWearSensors()
+    }
+
+    fun accept(intent: MainIntent) {
+        when (intent) {
+            MainIntent.CompleteOnboarding -> completeOnboarding()
+
+            MainIntent.StartMeasurement -> startMeasurement()
+
+            MainIntent.StopMeasurement -> measurementControl.stop().showFailure()
+
+            is MainIntent.AddAnnotation -> measurementControl.annotate(intent.text).showFailure()
+
+            is MainIntent.SetSamplingPeriod -> updatePreference(
+                AppPreferencesIntent.SetSensorSamplingPeriod(intent.index),
+            )
+
+            is MainIntent.SetLowBatteryRestriction -> updatePreference(
+                AppPreferencesIntent.SetLowBatteryRestriction(intent.enabled),
+            )
+
+            is MainIntent.SetWakeLock -> updatePreference(AppPreferencesIntent.SetWakeLock(intent.enabled))
+
+            is MainIntent.SetKeepScreenAwake -> updatePreference(
+                AppPreferencesIntent.SetKeepPhoneDisplayOn(intent.enabled),
+            )
+
+            is MainIntent.SetGpsInterval -> updatePreference(AppPreferencesIntent.SetGpsInterval(intent.seconds))
+
+            is MainIntent.SetGpsDistance -> updatePreference(AppPreferencesIntent.SetGpsMinDistance(intent.meters))
+
+            else -> reduce(intent)
+        }
+    }
+
+    fun handleStorageResult(resultIntent: Intent?) {
+        val persisted = resultIntent?.let(documentStorage::persist) ?: Result.failure(
+            com.motionapps.sensorbox.core.error.AppError(
+                com.motionapps.sensorbox.core.error.AppError.Kind.STORAGE,
+                "Select storage directory",
+            ),
+        )
+        mutableState.value = state.value.copy(
+            storagePath = documentStorage.displayPath().getOrNull(),
+            message = if (persisted.isSuccess) MainMessage.NONE else MainMessage.STORAGE_REQUIRED,
+        )
+    }
+
+    fun handlePermissionResult() {
+        val request = state.value.toMeasurementRequest()
+        val missing = measurementPermissions.missingPermissions(request, state.value.includesHeartRate())
+        if (missing.isEmpty()) startMeasurement() else showMessage(MainMessage.PERMISSION_REQUIRED)
+    }
+
+    fun showPrivacyRationale() {
+        hasChosenInitialRoute = true
+        reduce(MainIntent.Navigate(MainRoute.PRIVACY))
+    }
+
+    private fun initialState() = MainState(
+        sensors = getAvailableSensors(),
+        storagePath = documentStorage.displayPath().getOrNull(),
+    )
+
+    private fun observePreferences() {
+        viewModelScope.launch {
+            preferencesRepository.preferences.collect { result ->
+                result.fold(
+                    onSuccess = { preferences ->
+                        val route = initialRoute(preferences.hasCompletedIntro, preferences.hasAcceptedPolicy)
+                        mutableState.value = state.value.copy(
+                            preferences = preferences,
+                            hasLoadedPreferences = true,
+                            route = route,
+                        )
+                    },
+                    onFailure = {
+                        mutableState.value = state.value.copy(
+                            hasLoadedPreferences = true,
+                            message = MainMessage.MEASUREMENT_FAILED,
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    private fun initialRoute(completedIntro: Boolean, acceptedPolicy: Boolean): MainRoute {
+        if (hasChosenInitialRoute) return state.value.route
+        hasChosenInitialRoute = true
+        return if (completedIntro && acceptedPolicy) MainRoute.RECORD else MainRoute.ONBOARDING
+    }
+
+    private fun observeMeasurementSession() {
+        viewModelScope.launch {
+            sessionStore.state.collect { session ->
+                onSessionChanged(session)
+            }
+        }
+    }
+
+    private fun onSessionChanged(session: MeasurementSessionState) {
+        elapsedJob?.cancel()
+        mutableState.value = state.value.copy(session = session, elapsedSeconds = 0)
+        if (session is MeasurementSessionState.Running) startElapsedTicker(session.startedAtElapsedRealtime)
+    }
+
+    private fun startElapsedTicker(startedAt: Long) {
+        elapsedJob = viewModelScope.launch {
+            while (isActive) {
+                val seconds = (SystemClock.elapsedRealtime() - startedAt).coerceAtLeast(0) / 1_000L
+                mutableState.value = state.value.copy(elapsedSeconds = seconds)
+                delay(1_000L)
+            }
+        }
+    }
+
+    private fun observeWearConnection() {
+        viewModelScope.launch {
+            observeWearCapability(WEAR_APP_CAPABILITY)
+                .catch { error ->
+                    AppError.from(AppError.Kind.CONNECTIVITY, "Observe Wear connection", error)
+                    emit(WearConnection.Disconnected)
+                }
+                .collect { connection ->
+                    mutableState.value = state.value.copy(isWearConnected = connection is WearConnection.Connected)
+                    if (connection is WearConnection.Connected) {
+                        WearCommandCodec.encode(WearCommand.RequestSensorList).suspendFlatMap { payload ->
+                            sendWearMessage(WEAR_APP_CAPABILITY, WEAR_MESSAGE_PATH, payload)
+                        }
+                    } else {
+                        wearSensorCatalog.clear()
+                    }
+                }
+        }
+    }
+
+    private fun observeWearSensors() {
+        viewModelScope.launch {
+            wearSensorCatalog.sensors.collect { sensors ->
+                mutableState.value = state.value.copy(
+                    wearSensors = sensors.map { sensor ->
+                        SensorDescriptor(
+                            type = sensor.type,
+                            name = sensor.name,
+                            vendor = sensor.vendor,
+                            isHeartRate = sensor.isHeartRate,
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    private fun reduce(intent: MainIntent) {
+        val next = MainReducer.reduce(state.value, intent)
+        mutableState.value = next.state
+        next.effect?.let(mutableEffects::trySend)
+    }
+
+    private fun completeOnboarding() {
+        if (!documentStorage.hasStorage().getOrElse {
+                showMessage(MainMessage.STORAGE_REQUIRED)
+                return
+            }
+        ) {
+            showMessage(MainMessage.STORAGE_REQUIRED)
+            return
+        }
+        viewModelScope.launch {
+            preferencesRepository.dispatch(AppPreferencesIntent.AcceptPolicy).getOrElse {
+                showMessage(MainMessage.MEASUREMENT_FAILED)
+                return@launch
+            }
+            preferencesRepository.dispatch(AppPreferencesIntent.CompleteIntro).getOrElse {
+                showMessage(MainMessage.MEASUREMENT_FAILED)
+                return@launch
+            }
+            mutableState.value = state.value.copy(route = MainRoute.RECORD)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun startMeasurement() {
+        val request = state.value.toMeasurementRequest()
+        if (!request.hasAnySource()) {
+            showMessage(MainMessage.PICK_AT_LEAST_ONE_SOURCE)
+            return
+        }
+        if (!documentStorage.hasStorage().getOrElse {
+                showMessage(MainMessage.STORAGE_REQUIRED)
+                return
+            }
+        ) {
+            reduce(MainIntent.ChooseStorage)
+            showMessage(MainMessage.STORAGE_REQUIRED)
+            return
+        }
+        requestMissingPermissions(request)?.let {
+            mutableEffects.trySend(MainEffect.RequestPermissions(it))
+            return
+        }
+        startForegroundMeasurement(request)
+    }
+
+    private fun requestMissingPermissions(request: MeasurementRequest): Set<String>? {
+        val permissions = measurementPermissions.missingPermissions(request, state.value.includesHeartRate())
+        return permissions.takeIf(Set<String>::isNotEmpty)
+    }
+
+    private fun startForegroundMeasurement(request: MeasurementRequest) {
+        viewModelScope.launch {
+            val result = measurementControl.start(request)
+            if (result.isFailure) showMessage(MainMessage.MEASUREMENT_FAILED)
+        }
+    }
+
+    private fun updatePreference(intent: AppPreferencesIntent) {
+        viewModelScope.launch { preferencesRepository.dispatch(intent).showFailure() }
+    }
+
+    private fun showMessage(message: MainMessage) {
+        mutableState.value = state.value.copy(message = message)
+    }
+
+    private fun Result<*>.showFailure() {
+        if (isFailure) showMessage(MainMessage.MEASUREMENT_FAILED)
+    }
+
+    private fun MainState.toMeasurementRequest() = MeasurementRequest(
+        sensorIds = selectedSensorIds,
+        includesGps = includesGps,
+        samplingPeriodIndex = preferences.sensorSamplingPeriod,
+        stopOnLowBattery = preferences.restrictMeasurementOnLowBattery,
+        useWakeLock = preferences.useWakeLock,
+        gpsIntervalSeconds = preferences.gpsIntervalSeconds,
+        gpsMinDistanceMeters = preferences.gpsMinDistanceMeters,
+        wearSensorIds = selectedWearSensorIds,
+        wearIncludesGps = wearIncludesGps,
+        customName = customMeasurementName,
+        measurementType = measurementType,
+        delaySeconds = startDelaySeconds,
+        durationSeconds = if (measurementType == "TIMED") durationSeconds.coerceAtLeast(1) else 0,
+        notes = notes.lines().map(String::trim).filter(String::isNotEmpty),
+        alarmOffsetsSeconds = alarmOffsets.split(',', ';', ' ')
+            .mapNotNull(String::toIntOrNull).filter { it >= 0 },
+        activityRecognition = activityRecognition,
+        activityRecognitionPeriodSeconds = activityRecognitionPeriodSeconds,
+        significantMotion = significantMotion,
+    )
+
+    private fun MainState.includesHeartRate(): Boolean = sensors.any {
+        it.isHeartRate && it.type in selectedSensorIds
+    }
+
+    private fun MeasurementRequest.hasAnySource(): Boolean = sensorIds.isNotEmpty() || includesGps ||
+        wearSensorIds.isNotEmpty() || wearIncludesGps || activityRecognition || significantMotion
+}

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorBoxApp.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorBoxApp.kt
@@ -1,0 +1,214 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.motionapps.sensorservices.session.MeasurementSessionState
+
+@Composable
+fun SensorBoxApp(state: MainState, onIntent: (MainIntent) -> Unit) {
+    if (!state.hasLoadedPreferences) {
+        Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background))
+        return
+    }
+    if (state.preferences.keepPhoneDisplayOn && state.session is MeasurementSessionState.Running) {
+        KeepScreenAwake()
+    }
+    SensorBoxNavHost(state, onIntent)
+}
+
+@Composable
+private fun SensorBoxNavHost(state: MainState, onIntent: (MainIntent) -> Unit) {
+    val backStack = rememberNavBackStack(state.route)
+    val displayedRoute = state.displayedRoute()
+    SynchronizeBackStack(backStack, displayedRoute)
+    val navigateBack = { navigateBack(state, backStack, onIntent) }
+
+    NavDisplay(
+        backStack = backStack,
+        onBack = navigateBack,
+        transitionSpec = { forwardScreenTransition() },
+        popTransitionSpec = { backwardScreenTransition() },
+        predictivePopTransitionSpec = { backwardScreenTransition() },
+        entryProvider = entryProvider {
+            entry<MainRoute> { route ->
+                RouteContent(
+                    route = route,
+                    state = state,
+                    onIntent = onIntent,
+                    onBack = navigateBack,
+                )
+            }
+        },
+    )
+}
+
+private fun MainState.displayedRoute() = if (session is MeasurementSessionState.Running) {
+    MainRoute.ACTIVE_MEASUREMENT
+} else {
+    route
+}
+
+@Composable
+private fun SynchronizeBackStack(backStack: NavBackStack<NavKey>, displayedRoute: MainRoute) {
+    LaunchedEffect(displayedRoute) {
+        if (
+            displayedRoute != MainRoute.ACTIVE_MEASUREMENT &&
+            backStack.lastOrNull() == MainRoute.ACTIVE_MEASUREMENT
+        ) {
+            backStack.removeLastOrNull()
+        }
+        if (backStack.lastOrNull() != displayedRoute) {
+            if (displayedRoute.isRootDestination()) backStack.clear()
+            backStack.add(displayedRoute)
+        }
+    }
+}
+
+private fun navigateBack(state: MainState, backStack: NavBackStack<NavKey>, onIntent: (MainIntent) -> Unit) {
+    if (state.session is MeasurementSessionState.Running) return
+    if (backStack.size > 1) backStack.removeLastOrNull()
+    val destination = backStack.lastOrNull() as? MainRoute ?: MainRoute.RECORD
+    if (destination != MainRoute.ACTIVE_MEASUREMENT) onIntent(MainIntent.Navigate(destination))
+}
+
+private fun MainRoute.isRootDestination() = when (this) {
+    MainRoute.ONBOARDING,
+    MainRoute.RECORD,
+    -> true
+
+    MainRoute.ACTIVE_MEASUREMENT,
+    MainRoute.SENSOR_DETAILS,
+    MainRoute.SENSOR_PREVIEW,
+    MainRoute.SETUP,
+    MainRoute.SETTINGS,
+    MainRoute.LICENSES,
+    MainRoute.PRIVACY,
+    -> false
+}
+
+@Composable
+private fun RouteContent(route: MainRoute, state: MainState, onIntent: (MainIntent) -> Unit, onBack: () -> Unit) {
+    when (route) {
+        MainRoute.ONBOARDING -> OnboardingScreen(state, onIntent)
+
+        MainRoute.ACTIVE_MEASUREMENT -> FullScreen { modifier ->
+            ActiveMeasurementScreen(state, onIntent, modifier)
+        }
+
+        MainRoute.SENSOR_DETAILS -> FullScreen { modifier ->
+            SensorDetailsScreen(state, onBack, { onIntent(MainIntent.Navigate(MainRoute.SENSOR_PREVIEW)) }, modifier)
+        }
+
+        MainRoute.SENSOR_PREVIEW -> FullScreen { modifier ->
+            SensorPreviewScreen(state = state, onBack = onBack, modifier = modifier)
+        }
+
+        MainRoute.SETUP -> FullScreen { modifier ->
+            MeasurementSetupScreen(
+                state = state,
+                onIntent = onIntent,
+                modifier = modifier,
+                onBack = {
+                    onIntent(MainIntent.ReturnToSensorSelection)
+                    onBack()
+                },
+            )
+        }
+
+        MainRoute.LICENSES -> FullScreen { modifier ->
+            OpenSourceLicensesScreen(onBack = onBack, modifier = modifier)
+        }
+
+        MainRoute.RECORD -> FullScreen { modifier -> RecordScreen(state, onIntent, modifier) }
+
+        MainRoute.SETTINGS -> FullScreen { modifier ->
+            SettingsScreen(state = state, onIntent = onIntent, modifier = modifier, onBack = onBack)
+        }
+
+        MainRoute.PRIVACY -> FullScreen { modifier -> PrivacyScreen(onBack, modifier) }
+    }
+}
+
+private fun forwardScreenTransition(): ContentTransform =
+    (slideInHorizontally(screenTween()) { width -> width / SCREEN_SLIDE_DIVISOR } + fadeIn(screenFadeInTween()))
+        .togetherWith(
+            slideOutHorizontally(screenTween()) { width -> -width / SCREEN_SLIDE_DIVISOR } +
+                fadeOut(screenFadeOutTween()),
+        )
+
+private fun backwardScreenTransition(): ContentTransform =
+    (slideInHorizontally(screenTween()) { width -> -width / SCREEN_SLIDE_DIVISOR } + fadeIn(screenFadeInTween()))
+        .togetherWith(
+            slideOutHorizontally(screenTween()) { width -> width / SCREEN_SLIDE_DIVISOR } +
+                fadeOut(screenFadeOutTween()),
+        )
+
+private fun screenTween(): FiniteAnimationSpec<IntOffset> =
+    tween(SCREEN_TRANSITION_MILLIS, easing = FastOutSlowInEasing)
+
+private fun screenFadeInTween() = tween<Float>(SCREEN_FADE_IN_MILLIS, easing = FastOutSlowInEasing)
+
+private fun screenFadeOutTween() = tween<Float>(SCREEN_FADE_OUT_MILLIS, easing = FastOutSlowInEasing)
+
+private const val SCREEN_TRANSITION_MILLIS = 300
+private const val SCREEN_FADE_IN_MILLIS = 240
+private const val SCREEN_FADE_OUT_MILLIS = 180
+private const val SCREEN_SLIDE_DIVISOR = 5
+
+@Composable
+private fun KeepScreenAwake() {
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val wasKeptOn = view.keepScreenOn
+        view.keepScreenOn = true
+        onDispose { view.keepScreenOn = wasKeptOn }
+    }
+}
+
+@Composable
+private fun FullScreen(content: @Composable (Modifier) -> Unit) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.background) { padding ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentAlignment = Alignment.TopCenter,
+        ) {
+            content(
+                Modifier
+                    .widthIn(max = ADAPTIVE_CONTENT_MAX_WIDTH)
+                    .fillMaxWidth()
+                    .fillMaxHeight(),
+            )
+        }
+    }
+}
+
+private val ADAPTIVE_CONTENT_MAX_WIDTH = 840.dp

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorBoxComponents.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorBoxComponents.kt
@@ -1,0 +1,210 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+
+@Composable
+fun SensorBoxScreenHeader(title: String, subtitle: String, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(title, style = MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(6.dp))
+        Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Composable
+fun SensorBoxTopAppBar(title: String, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth().heightIn(min = 64.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_back_24),
+                contentDescription = stringResource(R.string.back),
+                modifier = Modifier.size(28.dp),
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = title,
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.headlineSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+fun SensorBoxBackButton(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier.heightIn(min = 48.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 0.dp, vertical = 8.dp),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_arrow_back_24),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(label, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+@Composable
+fun SensorBoxPanel(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.large,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        content = content,
+    )
+}
+
+@Composable
+fun SensorBoxPrimaryButton(label: String, onClick: () -> Unit, modifier: Modifier = Modifier, enabled: Boolean = true) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.height(52.dp),
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
+    ) {
+        Text(label, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+fun SensorBoxDangerButton(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.height(52.dp),
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.error,
+            contentColor = MaterialTheme.colorScheme.onError,
+        ),
+    ) {
+        Text(label, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+fun SensorBoxSecondaryButton(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.height(48.dp),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+    ) {
+        Text(label, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+fun SensorBoxBottomAction(
+    title: String,
+    description: String,
+    buttonLabel: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 8.dp,
+    ) {
+        Column(Modifier.padding(horizontal = 20.dp, vertical = 14.dp)) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(title, style = MaterialTheme.typography.labelLarge)
+                Text(description, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Spacer(Modifier.height(10.dp))
+            SensorBoxPrimaryButton(buttonLabel, onClick, Modifier.fillMaxWidth(), enabled)
+        }
+    }
+}
+
+@Composable
+fun SensorIdentity(sensor: SensorDescriptor, modifier: Modifier = Modifier) {
+    Image(
+        painter = painterResource(sensorIconResource(sensor.type)),
+        contentDescription = sensor.name,
+        modifier = modifier.size(54.dp),
+    )
+}
+
+@Composable
+fun SensorSelectionIndicator(selected: Boolean) {
+    val borderColor = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+    Box(
+        modifier = Modifier
+            .size(26.dp)
+            .border(2.dp, borderColor, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) Box(Modifier.size(12.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+    }
+}
+
+@Composable
+fun SettingSummary(title: String, description: String, trailing: @Composable () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                description,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(Modifier.width(14.dp))
+        trailing()
+    }
+}

--- a/app/src/test/java/com/motionapps/sensorbox/presentation/main/MainReducerTest.kt
+++ b/app/src/test/java/com/motionapps/sensorbox/presentation/main/MainReducerTest.kt
@@ -1,0 +1,118 @@
+package com.motionapps.sensorbox.presentation.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainReducerTest {
+    @Test
+    fun `Given an unselected sensor When toggled Then it becomes selected`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.ToggleSensor(sensorId = 1))
+
+        assertTrue(1 in actual.state.selectedSensorIds)
+    }
+
+    @Test
+    fun `Given record state When storage is requested Then picker effect is emitted`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.ChooseStorage)
+
+        assertEquals(MainEffect.PickStorageDirectory, actual.effect)
+    }
+
+    @Test
+    fun `Given GPS disabled When toggled Then GPS becomes enabled`() {
+        val givenState = MainStateFixtures.state(includesGps = false)
+
+        val actual = MainReducer.reduce(givenState, MainIntent.ToggleGps)
+
+        assertTrue(actual.state.includesGps)
+    }
+
+    @Test
+    fun `Given an unselected Wear sensor When toggled Then only Wear selection changes`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.ToggleWearSensor(sensorId = 21))
+
+        assertTrue(21 in actual.state.selectedWearSensorIds)
+        assertTrue(actual.state.selectedSensorIds.isEmpty())
+    }
+
+    @Test
+    fun `Given endless mode When timed mode is selected Then timing configuration is retained`() {
+        val givenState = MainStateFixtures.state().copy(durationSeconds = 60)
+
+        val actual = MainReducer.reduce(givenState, MainIntent.SetMeasurementType("TIMED"))
+
+        assertEquals("TIMED", actual.state.measurementType)
+        assertEquals(60, actual.state.durationSeconds)
+    }
+
+    @Test
+    fun `Given selected sensors When setup is opened Then setup route is shown`() {
+        val givenState = MainStateFixtures.state(selectedSensorIds = setOf(1))
+
+        val actual = MainReducer.reduce(givenState, MainIntent.OpenMeasurementSetup)
+
+        assertEquals(MainRoute.SETUP, actual.state.route)
+    }
+
+    @Test
+    fun `Given a sensor When its information is opened Then details route retains its type`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.OpenSensorDetails(sensorType = 1))
+
+        assertEquals(MainRoute.SENSOR_DETAILS, actual.state.route)
+        assertEquals(1, actual.state.detailsSensorType)
+    }
+
+    @Test
+    fun `Given measurement setup When returning Then sensor selection is shown`() {
+        val givenState = MainStateFixtures.state(route = MainRoute.SETUP, selectedSensorIds = setOf(1))
+
+        val actual = MainReducer.reduce(givenState, MainIntent.ReturnToSensorSelection)
+
+        assertEquals(MainRoute.RECORD, actual.state.route)
+    }
+
+    @Test
+    fun `Given later introduction page When going back Then previous page is shown`() {
+        val givenState = MainStateFixtures.state().copy(onboardingPage = 3)
+
+        val actual = MainReducer.reduce(givenState, MainIntent.RetreatOnboarding)
+
+        assertEquals(2, actual.state.onboardingPage)
+    }
+
+    @Test
+    fun `Given policy introduction When privacy is opened Then privacy effect is emitted`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.OpenPrivacyPolicy)
+
+        assertEquals(MainEffect.OpenPrivacyPolicy, actual.effect)
+    }
+
+    @Test
+    fun `Given policy introduction When terms are opened Then terms effect is emitted`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.OpenTermsOfUse)
+
+        assertEquals(MainEffect.OpenTermsOfUse, actual.effect)
+    }
+
+    @Test
+    fun `Given battery introduction When exemption is requested Then settings effect is emitted`() {
+        val givenState = MainStateFixtures.state()
+
+        val actual = MainReducer.reduce(givenState, MainIntent.RequestBatteryOptimizationExemption)
+
+        assertEquals(MainEffect.RequestBatteryOptimizationExemption, actual.effect)
+    }
+}

--- a/app/src/test/java/com/motionapps/sensorbox/presentation/main/MainStateFixtures.kt
+++ b/app/src/test/java/com/motionapps/sensorbox/presentation/main/MainStateFixtures.kt
@@ -1,0 +1,18 @@
+package com.motionapps.sensorbox.presentation.main
+
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+
+object MainStateFixtures {
+    fun state(
+        route: MainRoute = MainRoute.RECORD,
+        selectedSensorIds: Set<Int> = emptySet(),
+        includesGps: Boolean = false,
+    ) = MainState(
+        route = route,
+        sensors = listOf(
+            SensorDescriptor(type = 1, name = "Accelerometer", vendor = "Fixture", isHeartRate = false),
+        ),
+        selectedSensorIds = selectedSensorIds,
+        includesGps = includesGps,
+    )
+}


### PR DESCRIPTION
Creates the unidirectional state and navigation foundation for the phone Compose application.

## What was added

- Main state, intents, effects, and reducer contract.
- MainViewModel orchestration for preferences, sensors, measurement, and navigation.
- The root SensorBoxApp Compose navigation host.
- Shared Compose components plus reducer tests and state fixtures.

## How it works

Screens emit intents to MainViewModel. The reducer turns each intent into a new immutable state and optional one-time effect, and the root app renders the destination represented by that state. Shared components keep interaction and styling consistent across screens.

## Stack position

Layer 8 of 31 in the SensorBox refactor stack. Review this PR against its configured base to see only this layer.

## Validation

- Full stack: `./gradlew test` — BUILD SUCCESSFUL (160 tasks)