### PR TITLE
feat(app): add Compose recording flows

### DIFF
--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/ActiveMeasurementScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/ActiveMeasurementScreen.kt
@@ -1,0 +1,263 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.content.res.Resources
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.ui.theme.SensorBoxRecording
+import com.motionapps.sensorservices.session.MeasurementSessionState
+
+@Composable
+fun ActiveMeasurementScreen(state: MainState, onIntent: (MainIntent) -> Unit, modifier: Modifier = Modifier) {
+    val session = state.session as? MeasurementSessionState.Running ?: return
+    Column(
+        modifier = modifier.fillMaxSize().padding(horizontal = 20.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        RecordingHeader()
+        Column(
+            modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(48.dp))
+            MeasurementTimer(state.elapsedSeconds, session.folderName)
+            Spacer(Modifier.height(36.dp))
+            MeasurementSummary(state, session)
+            Spacer(Modifier.height(24.dp))
+            AnnotationEditor(onIntent)
+            Spacer(Modifier.height(24.dp))
+        }
+        SensorBoxDangerButton(
+            label = stringResource(R.string.stop_and_save),
+            onClick = { onIntent(MainIntent.StopMeasurement) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun AnnotationEditor(onIntent: (MainIntent) -> Unit) {
+    var annotation by remember { mutableStateOf("") }
+    SensorBoxPanel {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            OutlinedTextField(
+                value = annotation,
+                onValueChange = { annotation = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.annotation)) },
+                supportingText = { Text(stringResource(R.string.annotation_description)) },
+                singleLine = true,
+            )
+            SensorBoxSecondaryButton(
+                label = stringResource(R.string.add_annotation),
+                onClick = {
+                    annotation.trim().takeIf(String::isNotEmpty)?.let {
+                        onIntent(MainIntent.AddAnnotation(it))
+                        annotation = ""
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecordingHeader() {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RecordingIndicator()
+        Spacer(Modifier.size(8.dp))
+        Text(
+            stringResource(R.string.recording),
+            color = SensorBoxRecording,
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+@Composable
+private fun RecordingIndicator() {
+    val transition = rememberInfiniteTransition(label = "recording pulse")
+    val pulseAlpha by transition.animateFloat(
+        initialValue = RECORDING_DIM_ALPHA,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(RECORDING_PULSE_MILLIS, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "recording alpha",
+    )
+    val pulseScale by transition.animateFloat(
+        initialValue = RECORDING_MIN_SCALE,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(RECORDING_PULSE_MILLIS, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "recording scale",
+    )
+    Box(
+        Modifier
+            .size(12.dp)
+            .graphicsLayer {
+                alpha = pulseAlpha
+                scaleX = pulseScale
+                scaleY = pulseScale
+            }
+            .clip(CircleShape)
+            .background(SensorBoxRecording),
+    )
+}
+
+@Composable
+private fun MeasurementTimer(elapsedSeconds: Long, folderName: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(stringResource(R.string.elapsed_time), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(10.dp))
+        Text(formatElapsed(elapsedSeconds), style = MaterialTheme.typography.displayLarge)
+        Text(folderName, color = MaterialTheme.colorScheme.primary, textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+private fun MeasurementSummary(state: MainState, session: MeasurementSessionState.Running) {
+    var expanded by remember { mutableStateOf(false) }
+    val sources = recordingSourceNames(state, session, LocalContext.current.resources)
+    SensorBoxPanel {
+        Column(
+            Modifier.fillMaxWidth().padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                SummaryValue(sources.size.toString(), stringResource(R.string.sources))
+                SummaryValue(
+                    stringResource(if (session.includesGps) R.string.on else R.string.off),
+                    stringResource(R.string.gps),
+                )
+            }
+            SensorListToggle(expanded = expanded, onClick = { expanded = !expanded })
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                RecordingSourceList(sources)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SensorListToggle(expanded: Boolean, onClick: () -> Unit) {
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "sensor list arrow",
+    )
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.sensor_list),
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Icon(
+            painter = painterResource(R.drawable.ic_expand_more_24),
+            contentDescription = stringResource(if (expanded) R.string.hide_sensor_list else R.string.show_sensor_list),
+            modifier = Modifier.size(28.dp).rotate(arrowRotation),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun RecordingSourceList(sources: List<String>) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        sources.forEach { source ->
+            Text(source, style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+}
+
+private fun recordingSourceNames(
+    state: MainState,
+    session: MeasurementSessionState.Running,
+    resources: Resources,
+): List<String> = buildList {
+    session.sensorIds.forEach { sensorId ->
+        val sensorName = state.sensors.firstOrNull { sensor ->
+            sensor.type == sensorId
+        }?.name ?: resources.getString(R.string.sensor_number, sensorId)
+        add(sensorName)
+    }
+    if (session.includesGps) add(resources.getString(R.string.gps))
+}
+
+@Composable
+private fun SummaryValue(value: String, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, style = MaterialTheme.typography.headlineMedium)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+private fun formatElapsed(seconds: Long): String {
+    val hours = seconds / 3_600
+    val minutes = seconds % 3_600 / 60
+    val remainingSeconds = seconds % 60
+    return "%02d:%02d:%02d".format(hours, minutes, remainingSeconds)
+}
+
+private const val RECORDING_PULSE_MILLIS = 850
+private const val RECORDING_DIM_ALPHA = 0.28f
+private const val RECORDING_MIN_SCALE = 0.78f

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/MeasurementSetupScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/MeasurementSetupScreen.kt
@@ -1,0 +1,271 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+
+@Composable
+fun MeasurementSetupScreen(
+    state: MainState,
+    onIntent: (MainIntent) -> Unit,
+    modifier: Modifier = Modifier,
+    onBack: () -> Unit = { onIntent(MainIntent.ReturnToSensorSelection) },
+) {
+    Box(modifier.fillMaxSize()) {
+        MeasurementSetupContent(state, onIntent, onBack)
+        MeasurementSetupActionBar(state, onIntent, Modifier.align(Alignment.BottomCenter))
+    }
+}
+
+@Composable
+private fun MeasurementSetupContent(state: MainState, onIntent: (MainIntent) -> Unit, onBack: () -> Unit) {
+    LazyColumn(
+        contentPadding = PaddingValues(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 132.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item { SensorBoxTopAppBar(stringResource(R.string.measurement_setup), onBack) }
+        item { StorageSetupPanel(state.storagePath) { onIntent(MainIntent.ChooseStorage) } }
+        item { MeasurementNameSetup(state, onIntent) }
+        item { TimingSetup(state, onIntent) }
+        item { NotesAndAlarmsSetup(state, onIntent) }
+        item { SamplingSetting(state.preferences.sensorSamplingPeriod, onIntent) }
+        item { SpecializedSourcesSetup(state, onIntent) }
+        item { BatterySetup(state, onIntent) }
+        item { WakeLockSetup(state, onIntent) }
+        item { KeepScreenAwakeSetup(state, onIntent) }
+        if (state.includesGps) {
+            item { GpsIntervalSetup(state, onIntent) }
+            item { GpsDistanceSetup(state, onIntent) }
+        }
+        item { MainMessageText(state.message) }
+    }
+}
+
+@Composable
+private fun MeasurementNameSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    SensorBoxPanel {
+        OutlinedTextField(
+            value = state.customMeasurementName,
+            onValueChange = { onIntent(MainIntent.SetCustomMeasurementName(it)) },
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            label = { Text(stringResource(R.string.custom_measurement_name)) },
+            supportingText = { Text(stringResource(R.string.custom_measurement_name_description)) },
+            singleLine = true,
+        )
+    }
+}
+
+@Composable
+private fun TimingSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        BooleanSetting(
+            title = stringResource(R.string.timed_measurement),
+            description = stringResource(R.string.timed_measurement_description),
+            checked = state.measurementType == "TIMED",
+        ) { onIntent(MainIntent.SetMeasurementType(if (it) "TIMED" else "ENDLESS")) }
+        StepSetting(
+            stringResource(R.string.start_delay),
+            state.startDelaySeconds,
+            pluralStringResource(R.plurals.seconds_count, state.startDelaySeconds, state.startDelaySeconds),
+            0,
+            86_400,
+        ) { onIntent(MainIntent.SetStartDelay(it)) }
+        if (state.measurementType == "TIMED") {
+            StepSetting(
+                stringResource(R.string.measurement_duration),
+                state.durationSeconds.coerceAtLeast(1),
+                pluralStringResource(
+                    R.plurals.seconds_count,
+                    state.durationSeconds.coerceAtLeast(1),
+                    state.durationSeconds.coerceAtLeast(1),
+                ),
+                1,
+                86_400,
+            ) { onIntent(MainIntent.SetDuration(it)) }
+        }
+    }
+}
+
+@Composable
+private fun NotesAndAlarmsSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    SensorBoxPanel {
+        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(
+                value = state.notes,
+                onValueChange = { onIntent(MainIntent.SetNotes(it)) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.measurement_notes)) },
+                supportingText = { Text(stringResource(R.string.measurement_notes_description)) },
+                minLines = 2,
+            )
+            OutlinedTextField(
+                value = state.alarmOffsets,
+                onValueChange = { onIntent(MainIntent.SetAlarmOffsets(it)) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.audible_alarm_offsets)) },
+                supportingText = { Text(stringResource(R.string.audible_alarm_offsets_description)) },
+                singleLine = true,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpecializedSourcesSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        BooleanSetting(
+            title = stringResource(R.string.activity_recognition),
+            description = stringResource(R.string.activity_recognition_description),
+            checked = state.activityRecognition,
+        ) { onIntent(MainIntent.SetActivityRecognition(it)) }
+        if (state.activityRecognition) {
+            StepSetting(
+                stringResource(R.string.activity_recognition_period),
+                state.activityRecognitionPeriodSeconds,
+                pluralStringResource(
+                    R.plurals.seconds_count,
+                    state.activityRecognitionPeriodSeconds,
+                    state.activityRecognitionPeriodSeconds,
+                ),
+                1,
+                3_600,
+            ) { onIntent(MainIntent.SetActivityRecognitionPeriod(it)) }
+        }
+        BooleanSetting(
+            title = stringResource(R.string.significant_motion),
+            description = stringResource(R.string.significant_motion_description),
+            checked = state.significantMotion,
+        ) { onIntent(MainIntent.SetSignificantMotion(it)) }
+    }
+}
+
+@Composable
+private fun StorageSetupPanel(path: String?, onChoose: () -> Unit) {
+    SensorBoxPanel {
+        Row(Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primaryContainer) {
+                Icon(
+                    painterResource(R.drawable.ic_baseline_folder),
+                    null,
+                    Modifier.padding(12.dp).size(24.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(stringResource(R.string.recording_folder), style = MaterialTheme.typography.titleMedium)
+                Text(
+                    path ?: stringResource(R.string.choose_recording_folder),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            SensorBoxSecondaryButton(
+                stringResource(if (path == null) R.string.choose else R.string.change),
+                onChoose,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BatterySetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    BooleanSetting(
+        title = stringResource(R.string.battery_guard),
+        description = stringResource(R.string.battery_guard_setup_description),
+        checked = state.preferences.restrictMeasurementOnLowBattery,
+    ) { onIntent(MainIntent.SetLowBatteryRestriction(it)) }
+}
+
+@Composable
+private fun WakeLockSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    BooleanSetting(
+        title = stringResource(R.string.keep_cpu_awake),
+        description = stringResource(R.string.keep_cpu_awake_setup_description),
+        checked = state.preferences.useWakeLock,
+    ) { onIntent(MainIntent.SetWakeLock(it)) }
+}
+
+@Composable
+private fun KeepScreenAwakeSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    BooleanSetting(
+        title = stringResource(R.string.keep_screen_awake),
+        description = stringResource(R.string.keep_screen_awake_setup_description),
+        checked = state.preferences.keepPhoneDisplayOn,
+    ) { onIntent(MainIntent.SetKeepScreenAwake(it)) }
+}
+
+@Composable
+private fun GpsIntervalSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    StepSetting(
+        stringResource(R.string.gps_interval),
+        state.preferences.gpsIntervalSeconds,
+        pluralStringResource(
+            R.plurals.seconds_count,
+            state.preferences.gpsIntervalSeconds,
+            state.preferences.gpsIntervalSeconds,
+        ),
+        1,
+        3_600,
+    ) {
+        onIntent(MainIntent.SetGpsInterval(it))
+    }
+}
+
+@Composable
+private fun GpsDistanceSetup(state: MainState, onIntent: (MainIntent) -> Unit) {
+    StepSetting(
+        stringResource(R.string.gps_minimum_distance),
+        state.preferences.gpsMinDistanceMeters,
+        pluralStringResource(
+            R.plurals.meters_count,
+            state.preferences.gpsMinDistanceMeters,
+            state.preferences.gpsMinDistanceMeters,
+        ),
+        0,
+        10_000,
+    ) {
+        onIntent(MainIntent.SetGpsDistance(it))
+    }
+}
+
+@Composable
+private fun MeasurementSetupActionBar(state: MainState, onIntent: (MainIntent) -> Unit, modifier: Modifier = Modifier) {
+    val sourceCount = setupSourceCount(state)
+    SensorBoxBottomAction(
+        title = pluralStringResource(R.plurals.source_count, sourceCount, sourceCount),
+        description = stringResource(
+            if (state.storagePath == null) R.string.folder_required else R.string.ready_to_record,
+        ),
+        buttonLabel = stringResource(R.string.start_measurement),
+        enabled = state.storagePath != null && sourceCount > 0,
+        onClick = { onIntent(MainIntent.StartMeasurement) },
+        modifier = modifier,
+    )
+}
+
+private fun setupSourceCount(state: MainState): Int = state.selectedSensorIds.size + state.selectedWearSensorIds.size +
+    (if (state.includesGps) 1 else 0) + (if (state.wearIncludesGps) 1 else 0) +
+    (if (state.activityRecognition) 1 else 0) + (if (state.significantMotion) 1 else 0)

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/RecordScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/RecordScreen.kt
@@ -1,0 +1,252 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+
+@Composable
+fun RecordScreen(state: MainState, onIntent: (MainIntent) -> Unit, modifier: Modifier = Modifier) {
+    Box(modifier.fillMaxSize()) {
+        RecordContent(state, onIntent)
+        SensorSelectionActionBar(state, onIntent, Modifier.align(Alignment.BottomCenter))
+    }
+}
+
+@Composable
+private fun RecordContent(state: MainState, onIntent: (MainIntent) -> Unit) {
+    LazyColumn(
+        contentPadding = PaddingValues(start = 20.dp, top = 24.dp, end = 20.dp, bottom = 132.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item { RecordHeader(state) { onIntent(MainIntent.Navigate(MainRoute.SETTINGS)) } }
+        item { DeviceSectionHeader(stringResource(R.string.phone_sensors)) }
+        item { SensorSectionHeader(phoneSourceCount(state), state.sensors.size + 1) }
+        item {
+            GpsRow(
+                selected = state.includesGps,
+                onToggle = { onIntent(MainIntent.ToggleGps) },
+                onInfo = { onIntent(MainIntent.OpenSensorDetails(null)) },
+            )
+        }
+        items(state.sensors, key = SensorDescriptor::type) { sensor ->
+            SensorRow(
+                sensor = sensor,
+                selected = sensor.type in state.selectedSensorIds,
+                onToggle = { onIntent(MainIntent.ToggleSensor(sensor.type)) },
+                onInfo = { onIntent(MainIntent.OpenSensorDetails(sensor.type)) },
+            )
+        }
+        if (state.isWearConnected) {
+            item { DeviceSectionHeader(stringResource(R.string.wear_sensors)) }
+            item { SensorSectionHeader(wearSourceCount(state), state.wearSensors.size + 1) }
+            item {
+                GpsRow(
+                    selected = state.wearIncludesGps,
+                    onToggle = { onIntent(MainIntent.ToggleWearGps) },
+                    onInfo = { onIntent(MainIntent.OpenSensorDetails(null)) },
+                )
+            }
+            items(state.wearSensors, key = { "wear_${it.type}" }) { sensor ->
+                SensorRow(
+                    sensor = sensor,
+                    selected = sensor.type in state.selectedWearSensorIds,
+                    onToggle = { onIntent(MainIntent.ToggleWearSensor(sensor.type)) },
+                    onInfo = { onIntent(MainIntent.OpenSensorDetails(sensor.type)) },
+                )
+            }
+        }
+        item { MainMessageText(state.message) }
+    }
+}
+
+@Composable
+private fun DeviceSectionHeader(label: String) {
+    Text(
+        label,
+        modifier = Modifier.fillMaxWidth().padding(top = 14.dp),
+        style = MaterialTheme.typography.headlineSmall,
+        color = MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun GpsRow(selected: Boolean, onToggle: () -> Unit, onInfo: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.large,
+        border = BorderStroke(1.dp, sensorBorderColor(selected)),
+    ) {
+        Row(Modifier.padding(horizontal = 14.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Image(painterResource(R.drawable.ic_gps), stringResource(R.string.gps), Modifier.size(54.dp))
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(stringResource(R.string.gps), style = MaterialTheme.typography.titleMedium)
+                Text(stringResource(R.string.device_location), color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            SensorInformationButton(stringResource(R.string.information_about_gps), onInfo)
+            Spacer(Modifier.width(12.dp))
+            SensorSelectionIndicator(selected)
+        }
+    }
+}
+
+@Composable
+private fun RecordHeader(state: MainState, onOptions: () -> Unit) {
+    val optionsDescription = stringResource(R.string.options)
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+        SensorBoxScreenHeader(
+            title = stringResource(R.string.pick_sensors),
+            subtitle = stringResource(
+                if (state.isWearConnected) R.string.phone_and_wear_ready else R.string.choose_measurement_signals,
+            ),
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(12.dp))
+        Surface(
+            onClick = onOptions,
+            modifier = Modifier.size(48.dp).semantics { contentDescription = optionsDescription },
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    painterResource(R.drawable.ic_baseline_settings_24),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SensorSectionHeader(selected: Int, available: Int) {
+    Row(Modifier.fillMaxWidth().padding(top = 10.dp, bottom = 2.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(stringResource(R.string.sensors), style = MaterialTheme.typography.titleLarge)
+        Text(
+            stringResource(R.string.selected_count, selected, available),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SensorRow(sensor: SensorDescriptor, selected: Boolean, onToggle: () -> Unit, onInfo: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.large,
+        border = BorderStroke(1.dp, sensorBorderColor(selected)),
+    ) {
+        Row(Modifier.padding(horizontal = 14.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+            SensorIdentity(sensor)
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(sensor.name, style = MaterialTheme.typography.titleMedium)
+                Text(sensor.vendor, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            SensorInformationButton(stringResource(R.string.information_about_sensor, sensor.name), onInfo)
+            Spacer(Modifier.width(12.dp))
+            SensorSelectionIndicator(selected)
+        }
+    }
+}
+
+@Composable
+private fun SensorInformationButton(contentDescription: String, onClick: () -> Unit) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.size(40.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                stringResource(R.string.info_symbol),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.semantics { this.contentDescription = contentDescription },
+            )
+        }
+    }
+}
+
+@Composable
+private fun sensorBorderColor(selected: Boolean) =
+    if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+
+@Composable
+private fun SensorSelectionActionBar(state: MainState, onIntent: (MainIntent) -> Unit, modifier: Modifier = Modifier) {
+    val sensorCount = selectedSourceCount(state)
+    SensorBoxBottomAction(
+        title = pluralStringResource(R.plurals.sensor_count, sensorCount, sensorCount),
+        description = stringResource(R.string.step_one_of_two),
+        buttonLabel = stringResource(R.string.continue_action),
+        enabled = sensorCount > 0,
+        onClick = { onIntent(MainIntent.OpenMeasurementSetup) },
+        modifier = modifier,
+    )
+}
+
+private fun phoneSourceCount(state: MainState): Int = state.selectedSensorIds.size + if (state.includesGps) 1 else 0
+
+private fun wearSourceCount(state: MainState): Int =
+    state.selectedWearSensorIds.size + if (state.wearIncludesGps) 1 else 0
+
+private fun selectedSourceCount(state: MainState): Int = phoneSourceCount(state) + wearSourceCount(state) +
+    (if (state.activityRecognition) 1 else 0) + (if (state.significantMotion) 1 else 0)
+
+@Composable
+fun MainMessageText(message: MainMessage) {
+    if (message == MainMessage.NONE) return
+    Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) {
+        Text(
+            stringResource(messageTextResource(message)),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.padding(14.dp),
+        )
+    }
+}
+
+@StringRes
+private fun messageTextResource(message: MainMessage): Int = when (message) {
+    MainMessage.PICK_AT_LEAST_ONE_SOURCE -> R.string.message_pick_source
+    MainMessage.STORAGE_REQUIRED -> R.string.message_storage_required
+    MainMessage.PERMISSION_REQUIRED -> R.string.message_permission_required
+    MainMessage.MEASUREMENT_FAILED -> R.string.message_measurement_failed
+    MainMessage.NONE -> R.string.app_name
+}


### PR DESCRIPTION
Adds the complete phone recording flow in Compose.

## What was added

- Measurement setup UI for choosing sensors and recording options.
- Record screen for preparing and starting a session.
- Active measurement screen for status, elapsed time, and stop controls.

## How it works

Each screen renders values from the main state and emits typed intents for configuration changes or recording actions. MainViewModel delegates those intents to the measurement domain use cases, then updates the screen as the service session changes.

## Stack position

Layer 9 of 31 in the SensorBox refactor stack. Review this PR against its configured base to see only this layer.

## Validation

- Full stack: `./gradlew test` — BUILD SUCCESSFUL (160 tasks)