### PR TITLE
feat(app): add Compose sensor flows

### DIFF
--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorDetailsScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorDetailsScreen.kt
@@ -1,0 +1,293 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.location.Location
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationAvailability
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+import com.motionapps.sensorservices.handlers.GPSHandler
+
+@Composable
+fun SensorDetailsScreen(state: MainState, onBack: () -> Unit, onPreview: () -> Unit, modifier: Modifier = Modifier) {
+    val sensor = state.detailsSensorType?.let { type -> state.sensors.firstOrNull { it.type == type } }
+    val canPreview = state.detailsSensorType == null || sensor?.type != Sensor.TYPE_STEP_DETECTOR
+    val title = when {
+        state.detailsSensorType == null -> stringResource(R.string.gps)
+        sensor != null -> sensor.name
+        else -> stringResource(R.string.sensor_unavailable)
+    }
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { SensorBoxTopAppBar(title, onBack) }
+        if (state.detailsSensorType == null) {
+            item { GpsDetails(state) }
+        } else if (sensor != null) {
+            item { HardwareSensorDetails(sensor) }
+        }
+        if ((state.detailsSensorType == null || sensor != null) && canPreview) {
+            item {
+                SensorBoxPrimaryButton(
+                    label = stringResource(R.string.preview),
+                    onClick = onPreview,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HardwareSensorDetails(sensor: SensorDescriptor) {
+    SensorBoxPanel {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            val unit = sensorUnit(sensor.type)
+            val type = if (sensor.stringType.isBlank()) {
+                stringResource(R.string.detail_sensor_type_value, sensor.type)
+            } else {
+                sensor.stringType
+            }
+            DetailRow(stringResource(R.string.detail_name), sensor.name)
+            DetailRow(stringResource(R.string.detail_version), sensor.version.toString())
+            DetailRow(stringResource(R.string.detail_vendor), sensor.vendor)
+            DetailRow(stringResource(R.string.detail_resolution, unit), sensor.resolution.toString())
+            DetailRow(stringResource(R.string.detail_power), formatDecimal(sensor.power))
+            DetailRow(stringResource(R.string.detail_maximum_range, unit), formatDecimal(sensor.maximumRange))
+            DetailRow(
+                stringResource(R.string.detail_minimum_delay),
+                stringResource(R.string.detail_delay_value, sensor.minimumDelayMicros),
+            )
+            DetailRow(
+                stringResource(R.string.detail_maximum_delay),
+                stringResource(R.string.detail_delay_value, sensor.maximumDelayMicros),
+            )
+            DetailRow(
+                stringResource(R.string.detail_android_sensor_type),
+                type,
+            )
+            DetailRow(stringResource(R.string.detail_reporting_mode), reportingModeLabel(sensor.reportingMode))
+            DetailRow(
+                stringResource(R.string.detail_wakeup_sensor),
+                stringResource(if (sensor.isWakeUpSensor) R.string.yes else R.string.no),
+            )
+        }
+    }
+}
+
+@Composable
+private fun GpsDetails(state: MainState) {
+    var permissionRevision by remember { mutableStateOf(0) }
+    val permissionRequest = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) {
+        permissionRevision += 1
+    }
+    val details = rememberGpsDetails(
+        intervalSeconds = state.preferences.gpsIntervalSeconds,
+        minimumDistanceMeters = state.preferences.gpsMinDistanceMeters,
+        permissionRevision = permissionRevision,
+    )
+    val unavailableValue = stringResource(if (details.hasPermission) R.string.waiting else R.string.unavailable)
+    SensorBoxPanel {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            GpsPermission(details.hasPermission) {
+                permissionRequest.launch(
+                    arrayOf(
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                    ),
+                )
+            }
+            GpsDetailRows(details, state, unavailableValue)
+        }
+    }
+}
+
+@Composable
+private fun GpsDetailRows(details: GpsDetailsState, state: MainState, unavailableValue: String) {
+    DetailRow(
+        stringResource(R.string.detail_latitude),
+        details.location?.latitude?.toString() ?: unavailableValue,
+    )
+    DetailRow(
+        stringResource(R.string.detail_longitude),
+        details.location?.longitude?.toString() ?: unavailableValue,
+    )
+    DetailRow(stringResource(R.string.detail_altitude), localizedValue(details.location?.altitude, unavailableValue))
+    DetailRow(stringResource(R.string.detail_accuracy), localizedValue(details.location?.accuracy, unavailableValue))
+    DetailRow(stringResource(R.string.detail_speed), localizedValue(details.location?.speed, unavailableValue))
+    DetailRow(stringResource(R.string.detail_bearing), localizedValue(details.location?.bearing, unavailableValue))
+    DetailRow(stringResource(R.string.detail_provider), details.location?.provider ?: unavailableValue)
+    DetailRow(stringResource(R.string.detail_available), locationAvailabilityLabel(details.isAvailable))
+    DetailRow(
+        stringResource(R.string.detail_update_interval),
+        pluralStringResource(
+            R.plurals.seconds_count,
+            state.preferences.gpsIntervalSeconds,
+            state.preferences.gpsIntervalSeconds,
+        ),
+    )
+    DetailRow(
+        stringResource(R.string.detail_minimum_distance),
+        pluralStringResource(
+            R.plurals.meters_count,
+            state.preferences.gpsMinDistanceMeters,
+            state.preferences.gpsMinDistanceMeters,
+        ),
+    )
+}
+
+private fun localizedValue(value: Number?, unavailableValue: String): String =
+    value?.let(::formatDecimal) ?: unavailableValue
+
+@Composable
+internal fun GpsPermission(hasPermission: Boolean, onRequest: () -> Unit) {
+    DetailRow(
+        stringResource(R.string.location_permission),
+        stringResource(if (hasPermission) R.string.granted else R.string.required),
+    )
+    if (hasPermission) return
+    Text(
+        stringResource(R.string.location_permission_explanation),
+        color = MaterialTheme.colorScheme.error,
+    )
+    SensorBoxSecondaryButton(
+        label = stringResource(R.string.grant_location_permission),
+        onClick = onRequest,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+internal fun rememberGpsDetails(
+    intervalSeconds: Int,
+    minimumDistanceMeters: Int,
+    permissionRevision: Int,
+): GpsDetailsState {
+    val context = LocalContext.current
+    val hasPermission = remember(context, permissionRevision) { context.hasLocationPermission() }
+    var location by remember { mutableStateOf<Location?>(null) }
+    var isAvailable by remember { mutableStateOf<Boolean?>(null) }
+    val gpsHandler = remember { GPSHandler() }
+
+    DisposableEffect(gpsHandler, hasPermission, intervalSeconds, minimumDistanceMeters) {
+        var active = true
+        if (hasPermission) {
+            gpsHandler.configure(intervalSeconds, minimumDistanceMeters)
+            gpsHandler.addCallback(
+                context,
+                GpsDetailsCallback(
+                    onLocation = { if (active && it != null) location = it },
+                    onAvailability = { if (active) isAvailable = it },
+                ),
+            )
+        }
+        onDispose {
+            active = false
+            gpsHandler.gpsOff()
+        }
+    }
+    return GpsDetailsState(hasPermission, location, isAvailable)
+}
+
+@Composable
+internal fun DetailRow(label: String, value: String) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+        Text(label, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
+    }
+}
+
+@Composable
+private fun reportingModeLabel(mode: Int): String = when (mode) {
+    0 -> stringResource(R.string.reporting_continuous)
+    1 -> stringResource(R.string.reporting_on_change)
+    2 -> stringResource(R.string.reporting_one_shot)
+    3 -> stringResource(R.string.reporting_special_trigger)
+    else -> stringResource(R.string.unknown_with_value, mode)
+}
+
+@Composable
+internal fun sensorUnit(type: Int): String = when (type) {
+    Sensor.TYPE_ACCELEROMETER, Sensor.TYPE_GRAVITY, Sensor.TYPE_LINEAR_ACCELERATION ->
+        stringResource(R.string.unit_acceleration)
+
+    Sensor.TYPE_GYROSCOPE -> stringResource(R.string.unit_angular_velocity)
+
+    Sensor.TYPE_RELATIVE_HUMIDITY -> stringResource(R.string.unit_percent)
+
+    Sensor.TYPE_MAGNETIC_FIELD -> stringResource(R.string.unit_magnetic_field)
+
+    Sensor.TYPE_PROXIMITY -> stringResource(R.string.unit_centimeters)
+
+    Sensor.TYPE_PRESSURE -> stringResource(R.string.unit_pressure)
+
+    Sensor.TYPE_LIGHT -> stringResource(R.string.unit_lux)
+
+    Sensor.TYPE_AMBIENT_TEMPERATURE -> stringResource(R.string.unit_temperature)
+
+    Sensor.TYPE_STEP_COUNTER, Sensor.TYPE_STEP_DETECTOR -> stringResource(R.string.unit_steps)
+
+    Sensor.TYPE_HEART_RATE -> stringResource(R.string.unit_heart_rate)
+
+    else -> stringResource(R.string.unit_none)
+}
+
+internal fun formatDecimal(value: Number): String = "%.2f".format(value.toDouble())
+
+@Composable
+private fun locationAvailabilityLabel(isAvailable: Boolean?): String = when (isAvailable) {
+    true -> stringResource(R.string.yes)
+    false -> stringResource(R.string.no)
+    null -> stringResource(R.string.unknown)
+}
+
+private fun Context.hasLocationPermission(): Boolean =
+    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+
+internal data class GpsDetailsState(val hasPermission: Boolean, val location: Location?, val isAvailable: Boolean?)
+
+private class GpsDetailsCallback(
+    private val onLocation: (Location?) -> Unit,
+    private val onAvailability: (Boolean?) -> Unit,
+) : GPSHandler.OnLocationChangedCallback {
+    override fun onLocationChanged(location: Location?) = onLocation(location)
+
+    override fun onLastLocationSuccess(location: Location?) = onLocation(location)
+
+    override fun onAvailabilityChanged(locationAvailability: LocationAvailability?) =
+        onAvailability(locationAvailability?.isLocationAvailable)
+}

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorIconResource.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorIconResource.kt
@@ -1,0 +1,29 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.hardware.Sensor
+import androidx.annotation.DrawableRes
+import com.motionapps.sensorbox.R
+
+@DrawableRes
+fun sensorIconResource(sensorType: Int): Int = SENSOR_ICON_RESOURCES[sensorType] ?: R.drawable.ic_acceleration_icon
+
+private val SENSOR_ICON_RESOURCES = mapOf(
+    Sensor.TYPE_ACCELEROMETER to R.drawable.ic_acceleration_icon,
+    Sensor.TYPE_LINEAR_ACCELERATION to R.drawable.ic_linear_acceleration_icon,
+    Sensor.TYPE_GRAVITY to R.drawable.ic_gravity_icon,
+    Sensor.TYPE_GYROSCOPE to R.drawable.ic_gyroscope_icon,
+    Sensor.TYPE_GYROSCOPE_UNCALIBRATED to R.drawable.ic_gyroscope_icon,
+    Sensor.TYPE_RELATIVE_HUMIDITY to R.drawable.ic_water_drop,
+    Sensor.TYPE_MAGNETIC_FIELD to R.drawable.ic_magnet,
+    Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED to R.drawable.ic_magnet,
+    Sensor.TYPE_PROXIMITY to R.drawable.ic_proximity,
+    Sensor.TYPE_ROTATION_VECTOR to R.drawable.ic_rotation_icon,
+    Sensor.TYPE_GAME_ROTATION_VECTOR to R.drawable.ic_rotation_icon,
+    Sensor.TYPE_GEOMAGNETIC_ROTATION_VECTOR to R.drawable.ic_rotation_icon,
+    Sensor.TYPE_PRESSURE to R.drawable.ic_pressure,
+    Sensor.TYPE_LIGHT to R.drawable.ic_light,
+    Sensor.TYPE_AMBIENT_TEMPERATURE to R.drawable.ic_temperature,
+    Sensor.TYPE_STEP_COUNTER to R.drawable.ic_steps,
+    Sensor.TYPE_STEP_DETECTOR to R.drawable.ic_steps_detector,
+    Sensor.TYPE_HEART_RATE to R.drawable.ic_heart_rate,
+)

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorPreviewScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/SensorPreviewScreen.kt
@@ -1,0 +1,423 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.Manifest
+import android.graphics.Paint
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.domain.sensors.SensorDescriptor
+import kotlin.math.max
+
+@Composable
+fun SensorPreviewScreen(state: MainState, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val sensor = state.detailsSensorType?.let { type -> state.sensors.firstOrNull { it.type == type } }
+    val title = when {
+        state.detailsSensorType == null -> stringResource(R.string.gps_preview)
+        sensor != null -> stringResource(R.string.sensor_preview_title, sensor.name)
+        else -> stringResource(R.string.sensor_unavailable)
+    }
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item { SensorBoxTopAppBar(title, onBack) }
+        if (state.detailsSensorType == null) {
+            item { GpsPreview(state) }
+        } else if (sensor != null) {
+            item { HardwareSensorPreview(sensor) }
+        }
+    }
+}
+
+@Composable
+private fun HardwareSensorPreview(sensor: SensorDescriptor) {
+    val preview = rememberHardwareSensorPreview(sensor.type)
+    val latestValues = preview.samples.lastOrNull()?.values
+    val unit = sensorUnit(sensor.type)
+    SensorBoxPanel {
+        Column(
+            Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            if (!preview.isAvailable) {
+                Text(stringResource(R.string.sensor_activation_failed), color = MaterialTheme.colorScheme.error)
+                return@Column
+            }
+            if (sensor.type == Sensor.TYPE_STEP_COUNTER) {
+                StepCounterPreview(latestValues?.firstOrNull())
+            } else {
+                SensorValues(latestValues, unit)
+                Text(stringResource(R.string.live_chart), style = MaterialTheme.typography.titleMedium)
+                LiveSensorChart(preview.samples, unit)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepCounterPreview(value: Float?) {
+    if (value == null) {
+        Text(stringResource(R.string.waiting_sensor_data), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        return
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(value.toLong().toString(), style = MaterialTheme.typography.displayMedium)
+        Text(stringResource(R.string.unit_steps), color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun SensorValues(values: FloatArray?, unit: String) {
+    if (values == null) {
+        Text(stringResource(R.string.waiting_sensor_data), color = MaterialTheme.colorScheme.onSurfaceVariant)
+        return
+    }
+    values.forEachIndexed { index, value ->
+        DetailRow(
+            label = stringResource(R.string.sensor_value_with_unit, axisLabel(index, values.size), unit),
+            value = formatDecimal(value),
+        )
+    }
+}
+
+@Composable
+private fun LiveSensorChart(samples: List<TimedSensorSample>, unit: String) {
+    val axisCount = samples.maxOfOrNull { it.values.size }?.coerceAtMost(MAX_CHART_AXES) ?: 0
+    val colors = listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.error,
+        MaterialTheme.colorScheme.secondary,
+        MaterialTheme.colorScheme.onSurface,
+        MaterialTheme.colorScheme.outline,
+    )
+    val gridColor = MaterialTheme.colorScheme.outlineVariant
+    val axisColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val validValues = samples.flatMap { sample ->
+        sample.values.take(axisCount).filter(Float::isFinite)
+    }
+    val scale = chartScale(validValues)
+    val timeAxisLabel = stringResource(R.string.chart_time_axis)
+    val valueAxisLabel = stringResource(R.string.chart_value_axis, unit)
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        SensorChartCanvas(samples, axisCount, scale, colors, gridColor, axisColor, timeAxisLabel, valueAxisLabel)
+        if (axisCount > 0) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                repeat(axisCount) { axis -> ChartLegend(axisLabel(axis, axisCount), colors[axis]) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SensorChartCanvas(
+    samples: List<TimedSensorSample>,
+    axisCount: Int,
+    scale: ChartScale,
+    colors: List<Color>,
+    gridColor: Color,
+    axisColor: Color,
+    timeAxisLabel: String,
+    valueAxisLabel: String,
+) {
+    Canvas(Modifier.fillMaxWidth().height(CHART_HEIGHT)) {
+        val plot = ChartPlot(
+            left = CHART_LEFT_MARGIN.toPx(),
+            top = CHART_TOP_MARGIN.toPx(),
+            right = size.width - CHART_RIGHT_MARGIN.toPx(),
+            bottom = size.height - CHART_BOTTOM_MARGIN.toPx(),
+        )
+        drawChartAxes(plot, scale, samples, gridColor, axisColor, timeAxisLabel, valueAxisLabel)
+        if (samples.size < 2) return@Canvas
+        drawSensorLines(samples, axisCount, plot, scale, colors)
+    }
+}
+
+private fun chartScale(values: List<Float>): ChartScale {
+    if (values.isEmpty()) return ChartScale(-1f, 1f)
+    val rawMinimum = values.minOrNull() ?: -1f
+    val rawMaximum = values.maxOrNull() ?: 1f
+    val padding = max((rawMaximum - rawMinimum) * CHART_RANGE_PADDING, MIN_CHART_RANGE / 2f)
+    return ChartScale(rawMinimum - padding, rawMaximum + padding)
+}
+
+private fun DrawScope.drawChartAxes(
+    plot: ChartPlot,
+    scale: ChartScale,
+    samples: List<TimedSensorSample>,
+    gridColor: Color,
+    axisColor: Color,
+    timeAxisLabel: String,
+    valueAxisLabel: String,
+) {
+    val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = axisColor.toArgb()
+        textSize = 10.sp.toPx()
+    }
+    val titlePaint = Paint(labelPaint).apply { textSize = 11.sp.toPx() }
+    drawValueTicks(plot, scale, gridColor, labelPaint)
+    drawTimeTicks(plot, samples, gridColor, labelPaint)
+    drawLine(axisColor, Offset(plot.left, plot.top), Offset(plot.left, plot.bottom), 1.5.dp.toPx())
+    drawLine(axisColor, Offset(plot.left, plot.bottom), Offset(plot.right, plot.bottom), 1.5.dp.toPx())
+    drawAxisTitles(plot, timeAxisLabel, valueAxisLabel, titlePaint)
+}
+
+private fun DrawScope.drawValueTicks(plot: ChartPlot, scale: ChartScale, gridColor: Color, paint: Paint) {
+    paint.textAlign = Paint.Align.RIGHT
+    repeat(GRID_LINE_COUNT) { index ->
+        val fraction = index.toFloat() / (GRID_LINE_COUNT - 1)
+        val y = plot.bottom - plot.height * fraction
+        val value = scale.minimum + scale.range * fraction
+        drawLine(gridColor, Offset(plot.left, y), Offset(plot.right, y), 1.dp.toPx())
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(formatChartValue(value), plot.left - 7.dp.toPx(), y + 3.dp.toPx(), paint)
+        }
+    }
+    if (scale.minimum < 0f && scale.maximum > 0f) {
+        val zeroY = plot.bottom - plot.height * (-scale.minimum / scale.range)
+        drawLine(gridColor, Offset(plot.left, zeroY), Offset(plot.right, zeroY), 2.dp.toPx())
+    }
+}
+
+private fun DrawScope.drawTimeTicks(
+    plot: ChartPlot,
+    samples: List<TimedSensorSample>,
+    gridColor: Color,
+    paint: Paint,
+) {
+    paint.textAlign = Paint.Align.CENTER
+    val durationSeconds = samples.durationSeconds()
+    repeat(TIME_TICK_COUNT) { index ->
+        val fraction = index.toFloat() / (TIME_TICK_COUNT - 1)
+        val x = plot.left + plot.width * fraction
+        drawLine(gridColor, Offset(x, plot.top), Offset(x, plot.bottom), 1.dp.toPx())
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                formatChartTime(durationSeconds * fraction),
+                x,
+                plot.bottom + 14.dp.toPx(),
+                paint,
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawAxisTitles(plot: ChartPlot, timeTitle: String, valueTitle: String, paint: Paint) {
+    paint.textAlign = Paint.Align.CENTER
+    drawIntoCanvas { canvas ->
+        val nativeCanvas = canvas.nativeCanvas
+        nativeCanvas.drawText(timeTitle, plot.left + plot.width / 2f, size.height - 2.dp.toPx(), paint)
+        val centerY = plot.top + plot.height / 2f
+        val titleX = 10.dp.toPx()
+        nativeCanvas.save()
+        nativeCanvas.rotate(-90f, titleX, centerY)
+        nativeCanvas.drawText(valueTitle, titleX, centerY, paint)
+        nativeCanvas.restore()
+    }
+}
+
+private fun DrawScope.drawSensorLines(
+    samples: List<TimedSensorSample>,
+    axisCount: Int,
+    plot: ChartPlot,
+    scale: ChartScale,
+    colors: List<Color>,
+) {
+    val firstTimestamp = samples.first().timestampNanos
+    val durationNanos = (samples.last().timestampNanos - firstTimestamp).coerceAtLeast(1L)
+    repeat(axisCount) { axis ->
+        val path = Path()
+        var hasPoint = false
+        samples.forEach { sample ->
+            val value = sample.values.getOrNull(axis)?.takeIf(Float::isFinite) ?: return@forEach
+            val elapsedFraction = (sample.timestampNanos - firstTimestamp).toFloat() / durationNanos
+            val x = plot.left + plot.width * elapsedFraction
+            val y = plot.bottom - plot.height * ((value - scale.minimum) / scale.range)
+            if (hasPoint) path.lineTo(x, y) else path.moveTo(x, y)
+            hasPoint = true
+        }
+        drawPath(path, colors[axis], style = Stroke(width = 2.5.dp.toPx()))
+    }
+}
+
+private fun List<TimedSensorSample>.durationSeconds(): Float =
+    if (size < 2) 0f else (last().timestampNanos - first().timestampNanos) / NANOS_PER_SECOND
+
+private fun formatChartTime(seconds: Float): String = "%.1f".format(seconds)
+
+private fun formatChartValue(value: Float): String = when {
+    kotlin.math.abs(value) >= 100f -> "%.0f".format(value)
+    kotlin.math.abs(value) >= 10f -> "%.1f".format(value)
+    else -> "%.2f".format(value)
+}
+
+@Composable
+private fun ChartLegend(label: String, color: Color) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+        Box(Modifier.size(8.dp).background(color, CircleShape))
+        Text(label, style = MaterialTheme.typography.labelMedium)
+    }
+}
+
+@Composable
+private fun GpsPreview(state: MainState) {
+    var permissionRevision by remember { mutableIntStateOf(0) }
+    val permissionRequest = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) {
+        permissionRevision += 1
+    }
+    val details = rememberGpsDetails(
+        intervalSeconds = state.preferences.gpsIntervalSeconds,
+        minimumDistanceMeters = state.preferences.gpsMinDistanceMeters,
+        permissionRevision = permissionRevision,
+    )
+    val unavailableValue = stringResource(if (details.hasPermission) R.string.waiting else R.string.unavailable)
+    GpsPreviewPanel(details, unavailableValue) {
+        permissionRequest.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun GpsPreviewPanel(details: GpsDetailsState, unavailableValue: String, onRequestPermission: () -> Unit) {
+    SensorBoxPanel {
+        Column(Modifier.fillMaxWidth().padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            GpsPermission(details.hasPermission, onRequestPermission)
+            DetailRow(
+                stringResource(R.string.detail_latitude),
+                details.location?.latitude?.toString() ?: unavailableValue,
+            )
+            DetailRow(
+                stringResource(R.string.detail_longitude),
+                details.location?.longitude?.toString() ?: unavailableValue,
+            )
+            DetailRow(
+                stringResource(R.string.detail_altitude),
+                details.location?.altitude?.let(::formatDecimal) ?: unavailableValue,
+            )
+            DetailRow(
+                stringResource(R.string.detail_bearing),
+                details.location?.bearing?.let(::formatDecimal) ?: unavailableValue,
+            )
+        }
+    }
+}
+
+@Composable
+private fun rememberHardwareSensorPreview(sensorType: Int): HardwareSensorPreviewState {
+    val context = LocalContext.current
+    val sensorManager = remember(context) { context.getSystemService(SensorManager::class.java) }
+    val sensor = remember(sensorManager, sensorType) { sensorManager?.getDefaultSensor(sensorType) }
+    var samples by remember(sensorType) { mutableStateOf(emptyList<TimedSensorSample>()) }
+    var isAvailable by remember(sensorType) { mutableStateOf(sensor != null) }
+
+    DisposableEffect(sensorManager, sensor) {
+        if (sensorManager == null || sensor == null) {
+            isAvailable = false
+            onDispose { }
+        } else {
+            val listener = object : SensorEventListener {
+                override fun onSensorChanged(event: SensorEvent) {
+                    val sample = TimedSensorSample(event.timestamp, event.values.copyOf())
+                    samples = (samples + sample).takeLast(MAX_CHART_SAMPLES)
+                }
+
+                override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+            }
+            isAvailable = sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_UI)
+            onDispose { sensorManager.unregisterListener(listener) }
+        }
+    }
+    return HardwareSensorPreviewState(isAvailable, samples)
+}
+
+@Composable
+private fun axisLabel(index: Int, axisCount: Int): String = when {
+    axisCount == 1 -> stringResource(R.string.value)
+    index == 0 -> stringResource(R.string.axis_x)
+    index == 1 -> stringResource(R.string.axis_y)
+    index == 2 -> stringResource(R.string.axis_z)
+    index == 3 -> stringResource(R.string.axis_w)
+    else -> stringResource(R.string.value_number, index + 1)
+}
+
+private data class HardwareSensorPreviewState(val isAvailable: Boolean, val samples: List<TimedSensorSample>)
+
+private data class TimedSensorSample(val timestampNanos: Long, val values: FloatArray)
+
+private data class ChartScale(val minimum: Float, val maximum: Float) {
+    val range: Float = maximum - minimum
+}
+
+private data class ChartPlot(val left: Float, val top: Float, val right: Float, val bottom: Float) {
+    val width: Float = right - left
+    val height: Float = bottom - top
+}
+
+private val CHART_HEIGHT = 220.dp
+private val CHART_LEFT_MARGIN = 56.dp
+private val CHART_RIGHT_MARGIN = 10.dp
+private val CHART_TOP_MARGIN = 10.dp
+private val CHART_BOTTOM_MARGIN = 42.dp
+private const val MAX_CHART_SAMPLES = 90
+private const val MAX_CHART_AXES = 6
+private const val GRID_LINE_COUNT = 5
+private const val TIME_TICK_COUNT = 3
+private const val MIN_CHART_RANGE = 0.001f
+private const val CHART_RANGE_PADDING = 0.08f
+private const val NANOS_PER_SECOND = 1_000_000_000f


### PR DESCRIPTION
Adds Compose screens for browsing, previewing, and understanding available sensors.

## What was added

- Sensor preview list and live-value presentation.
- Detailed sensor metadata screen.
- Central mapping from sensor types to icon resources.

## How it works

Domain SensorDescriptor values are rendered by the preview screen. Selecting a sensor navigates to the details view, while observed values refresh the preview through state updates. Icon mapping keeps platform sensor identifiers out of the UI components.

## Stack position

Layer 10 of 31 in the SensorBox refactor stack. Review this PR against its configured base to see only this layer.

## Validation

- Full stack: `./gradlew test` — BUILD SUCCESSFUL (160 tasks)