### PR TITLE
feat(app): add Compose onboarding and about flows

### DIFF
--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/AboutScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/AboutScreen.kt
@@ -1,0 +1,147 @@
+package com.motionapps.sensorbox.presentation.main
+
+import android.content.res.Resources
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.BuildConfig
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+
+@Composable
+fun AboutDialog(onDismiss: () -> Unit, onPrivacy: () -> Unit, onLicenses: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Image(
+                painter = painterResource(R.drawable.ic_launcher_historic_round),
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+            )
+        },
+        title = { Text(stringResource(R.string.about_title)) },
+        text = { AboutDialogBody(onPrivacy) },
+        confirmButton = {
+            TextButton(onClick = onLicenses) {
+                Text(stringResource(R.string.about_licenses))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.close))
+            }
+        },
+    )
+}
+
+@Composable
+private fun AboutDialogBody(onPrivacy: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            stringResource(R.string.about_version, BuildConfig.VERSION_NAME),
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            stringResource(R.string.about_app_description),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TextButton(onClick = onPrivacy, contentPadding = PaddingValues(0.dp)) {
+            Text(stringResource(R.string.about_privacy_policy))
+        }
+    }
+}
+
+@Composable
+fun OpenSourceLicensesScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val resources = LocalContext.current.resources
+    val licenses = remember(resources) {
+        appResult(AppError.Kind.STORAGE, "Load open source licenses") {
+            loadOpenSourceLicenses(resources)
+        }.getOrDefault(emptyList())
+    }
+    var selectedLicense by remember { mutableStateOf<OpenSourceLicense?>(null) }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        item { SensorBoxTopAppBar(stringResource(R.string.about_licenses), onBack) }
+        items(licenses, key = OpenSourceLicense::name) { license ->
+            Surface(
+                modifier = Modifier.fillMaxWidth().clickable { selectedLicense = license },
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.large,
+            ) {
+                Text(
+                    text = license.name,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+    }
+
+    selectedLicense?.let { license ->
+        AlertDialog(
+            onDismissRequest = { selectedLicense = null },
+            title = { Text(license.name) },
+            text = {
+                Box(Modifier.heightIn(max = 480.dp).verticalScroll(rememberScrollState())) {
+                    Text(license.text, style = MaterialTheme.typography.bodySmall)
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { selectedLicense = null }) {
+                    Text(stringResource(R.string.close))
+                }
+            },
+        )
+    }
+}
+
+private data class OpenSourceLicense(val name: String, val text: String)
+
+private fun loadOpenSourceLicenses(resources: Resources): List<OpenSourceLicense> {
+    val licenseBytes = resources.openRawResource(R.raw.third_party_licenses).use { it.readBytes() }
+    return resources.openRawResource(R.raw.third_party_license_metadata).bufferedReader().useLines { lines ->
+        lines.mapNotNull { line ->
+            val location = line.substringBefore(' ')
+            val name = line.substringAfter(' ', missingDelimiterValue = "").trim()
+            val offset = location.substringBefore(':').toIntOrNull()
+            val length = location.substringAfter(':', missingDelimiterValue = "").toIntOrNull()
+            if (name.isEmpty() || offset == null || length == null || offset + length > licenseBytes.size) {
+                return@mapNotNull null
+            }
+            OpenSourceLicense(name, licenseBytes.decodeToString(offset, offset + length).trim())
+        }.distinctBy(OpenSourceLicense::name).sortedBy { it.name.lowercase() }.toList()
+    }
+}

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/OnboardingScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/OnboardingScreen.kt
@@ -1,0 +1,337 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+
+@Composable
+fun OnboardingScreen(state: MainState, onIntent: (MainIntent) -> Unit) {
+    val pageIndex = state.onboardingPage.coerceIn(ONBOARDING_PAGES.indices)
+    val page = ONBOARDING_PAGES[pageIndex]
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        val isLandscape = maxWidth > maxHeight
+        OnboardingLayout(pageIndex, page, state, isLandscape, onIntent)
+    }
+}
+
+@Composable
+private fun OnboardingLayout(
+    pageIndex: Int,
+    page: OnboardingPage,
+    state: MainState,
+    isLandscape: Boolean,
+    onIntent: (MainIntent) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = ONBOARDING_MAX_WIDTH)
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = if (isLandscape) 12.dp else 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        OnboardingHeader(pageIndex, onIntent)
+        Box(Modifier.fillMaxWidth().weight(1f), contentAlignment = Alignment.TopCenter) {
+            OnboardingMessage(page, state, isLandscape, onIntent)
+        }
+        OnboardingControls(
+            pageIndex = pageIndex,
+            hasStorage = state.storagePath != null,
+            isLandscape = isLandscape,
+            onIntent = onIntent,
+            modifier = Modifier.padding(bottom = if (isLandscape) 0.dp else 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun OnboardingHeader(pageIndex: Int, onIntent: (MainIntent) -> Unit) {
+    Column(Modifier.fillMaxWidth()) {
+        Box(Modifier.fillMaxWidth().height(52.dp)) {
+            if (pageIndex > 0) {
+                SensorBoxBackButton(
+                    label = stringResource(R.string.intro_back),
+                    onClick = { onIntent(MainIntent.RetreatOnboarding) },
+                    modifier = Modifier.align(Alignment.CenterStart),
+                )
+            }
+            Text(
+                stringResource(R.string.intro_page_progress, pageIndex + 1, ONBOARDING_PAGES.size),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.align(Alignment.CenterEnd),
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnboardingProgress(pageIndex: Int) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        ONBOARDING_PAGES.indices.forEach { index ->
+            val color = if (index <= pageIndex) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outlineVariant
+            }
+            Box(Modifier.size(8.dp).clip(CircleShape).background(color))
+        }
+    }
+}
+
+@Composable
+private fun OnboardingMessage(
+    page: OnboardingPage,
+    state: MainState,
+    isLandscape: Boolean,
+    onIntent: (MainIntent) -> Unit,
+) {
+    if (isLandscape) {
+        LandscapeOnboardingMessage(page, state, onIntent)
+    } else {
+        PortraitOnboardingMessage(page, state, onIntent)
+    }
+}
+
+@Composable
+private fun PortraitOnboardingMessage(page: OnboardingPage, state: MainState, onIntent: (MainIntent) -> Unit) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = ONBOARDING_MESSAGE_MAX_WIDTH)
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(top = 72.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        OnboardingIllustration(page)
+        Spacer(Modifier.height(24.dp))
+        OnboardingText(page)
+        Spacer(Modifier.height(18.dp))
+        OnboardingPageActions(page.action, state.storagePath, onIntent)
+    }
+}
+
+@Composable
+private fun LandscapeOnboardingMessage(page: OnboardingPage, state: MainState, onIntent: (MainIntent) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OnboardingIllustration(page, containerSize = 104.dp, imageSize = 64.dp)
+        Spacer(Modifier.width(32.dp))
+        Column(
+            modifier = Modifier.widthIn(max = ONBOARDING_MESSAGE_MAX_WIDTH).weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            OnboardingText(page)
+            Spacer(Modifier.height(12.dp))
+            OnboardingPageActions(page.action, state.storagePath, onIntent)
+        }
+    }
+}
+
+@Composable
+private fun OnboardingIllustration(page: OnboardingPage, containerSize: Dp = 124.dp, imageSize: Dp = 76.dp) {
+    Box(
+        modifier = Modifier
+            .size(containerSize)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(page.image),
+            contentDescription = stringResource(page.title),
+            modifier = Modifier.size(imageSize),
+        )
+    }
+}
+
+@Composable
+private fun OnboardingText(page: OnboardingPage) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            stringResource(page.title),
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            stringResource(page.body),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun OnboardingPageActions(action: OnboardingAction, path: String?, onIntent: (MainIntent) -> Unit) {
+    when (action) {
+        OnboardingAction.NONE -> Unit
+        OnboardingAction.POLICIES -> PolicyActions(onIntent)
+        OnboardingAction.BATTERY -> BatteryAction(onIntent)
+        OnboardingAction.STORAGE -> StorageAction(path, onIntent)
+    }
+}
+
+@Composable
+private fun PolicyActions(onIntent: (MainIntent) -> Unit) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        SensorBoxSecondaryButton(
+            label = stringResource(R.string.intro_policy_button),
+            onClick = { onIntent(MainIntent.OpenPrivacyPolicy) },
+            modifier = Modifier.weight(1f),
+        )
+        SensorBoxSecondaryButton(
+            label = stringResource(R.string.intro_terms_button),
+            onClick = { onIntent(MainIntent.OpenTermsOfUse) },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun BatteryAction(onIntent: (MainIntent) -> Unit) {
+    SensorBoxSecondaryButton(
+        label = stringResource(R.string.intro_battery_action),
+        onClick = { onIntent(MainIntent.RequestBatteryOptimizationExemption) },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun StorageAction(path: String?, onIntent: (MainIntent) -> Unit) {
+    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        SensorBoxSecondaryButton(
+            label = stringResource(
+                if (path == null) R.string.intro_storage_action else R.string.intro_storage_change_action,
+            ),
+            onClick = { onIntent(MainIntent.ChooseStorage) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (path != null) {
+            Spacer(Modifier.height(10.dp))
+            Text(
+                stringResource(R.string.intro_storage_selected, path),
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnboardingControls(
+    pageIndex: Int,
+    hasStorage: Boolean,
+    isLandscape: Boolean,
+    onIntent: (MainIntent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isLastPage = pageIndex == ONBOARDING_PAGES.lastIndex
+    Column(modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        OnboardingProgress(pageIndex)
+        Spacer(Modifier.height(if (isLandscape) 12.dp else 20.dp))
+        SensorBoxPrimaryButton(
+            label = stringResource(if (isLastPage) R.string.intro_finish else R.string.next),
+            onClick = { onIntent(onboardingForwardIntent(isLastPage)) },
+            modifier = Modifier.widthIn(max = ONBOARDING_MESSAGE_MAX_WIDTH).fillMaxWidth(),
+            enabled = !isLastPage || hasStorage,
+        )
+    }
+}
+
+private fun onboardingForwardIntent(isLastPage: Boolean): MainIntent =
+    if (isLastPage) MainIntent.CompleteOnboarding else MainIntent.AdvanceOnboarding
+
+private data class OnboardingPage(
+    @StringRes val title: Int,
+    @StringRes val body: Int,
+    @DrawableRes val image: Int,
+    val action: OnboardingAction = OnboardingAction.NONE,
+)
+
+private enum class OnboardingAction { NONE, POLICIES, BATTERY, STORAGE }
+
+private val ONBOARDING_MAX_WIDTH = 960.dp
+private val ONBOARDING_MESSAGE_MAX_WIDTH = 520.dp
+
+private val ONBOARDING_PAGES = listOf(
+    OnboardingPage(
+        R.string.intro_welcome_title,
+        R.string.intro_welcome_body,
+        R.drawable.ic_launcher_historic_round,
+    ),
+    OnboardingPage(
+        R.string.intro_incognito_title,
+        R.string.intro_incognito_body,
+        R.drawable.ic_incognito,
+    ),
+    OnboardingPage(
+        R.string.intro_policy_title,
+        R.string.intro_policy_body,
+        R.drawable.ic_bug,
+        OnboardingAction.POLICIES,
+    ),
+    OnboardingPage(
+        R.string.intro_lifecycle_title,
+        R.string.intro_lifecycle_body,
+        R.drawable.ic_android_big,
+    ),
+    OnboardingPage(
+        R.string.intro_battery_title,
+        R.string.intro_battery_body,
+        R.drawable.ic_battery,
+        OnboardingAction.BATTERY,
+    ),
+    OnboardingPage(
+        R.string.intro_storage_title,
+        R.string.intro_storage_body,
+        R.drawable.ic_folder,
+        OnboardingAction.STORAGE,
+    ),
+)

--- a/app/src/main/java/com/motionapps/sensorbox/presentation/main/PrivacyScreen.kt
+++ b/app/src/main/java/com/motionapps/sensorbox/presentation/main/PrivacyScreen.kt
@@ -1,0 +1,37 @@
+package com.motionapps.sensorbox.presentation.main
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.motionapps.sensorbox.R
+
+@Composable
+fun PrivacyScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        item { SensorBoxTopAppBar(stringResource(R.string.privacy_health_data), onBack) }
+        item { Text(stringResource(R.string.dialog_privacy_policy)) }
+        item { Text(stringResource(R.string.privacy_access_title), style = MaterialTheme.typography.titleLarge) }
+        item {
+            Text(
+                stringResource(R.string.privacy_permissions_body),
+            )
+        }
+        item { Text(stringResource(R.string.privacy_storage_body)) }
+        item {
+            Text(stringResource(R.string.privacy_heart_rate_body))
+        }
+        item { Text(stringResource(R.string.privacy_no_upload_body)) }
+    }
+}


### PR DESCRIPTION
Replaces the legacy introduction flow with Compose onboarding, privacy, and project information screens.

## What was added

- Guided onboarding for privacy, storage, lifecycle, and battery requirements.
- A dedicated privacy-policy screen.
- An About screen for project and open-source information.

## How it works

The onboarding screen advances through requirement-specific pages and emits intents when the user grants access or acknowledges a step. Completion is stored in preferences, allowing the root navigation state to enter the main application on subsequent launches.

## Stack position

Layer 12 of 31 in the SensorBox refactor stack. Review this PR against its configured base to see only this layer.

## Validation

- Full stack: `./gradlew test` — BUILD SUCCESSFUL (160 tasks)