### PR TITLE
[01/39] refactor: add shared core foundations

### DIFF
--- a/core/src/main/java/com/motionapps/sensorbox/core/error/AppDiagnostics.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/error/AppDiagnostics.kt
@@ -1,0 +1,112 @@
+package com.motionapps.sensorbox.core.error
+
+import android.content.Context
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object AppDiagnostics {
+    private val lock = Any()
+    private val pending = ArrayDeque<String>()
+
+    @Volatile
+    private var applicationContext: Context? = null
+
+    @Volatile
+    private var uncaughtHandlerInstalled = false
+
+    fun install(context: Context) {
+        synchronized(lock) {
+            applicationContext = context.applicationContext
+            installUncaughtExceptionHandler()
+            val queued = pending.toList()
+            pending.clear()
+            queued.forEach(::appendSafely)
+        }
+    }
+
+    private fun installUncaughtExceptionHandler() {
+        if (uncaughtHandlerInstalled) return
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, error ->
+            AppError.from(AppError.Kind.UNKNOWN, "Uncaught exception on ${thread.name}", error)
+            previous?.uncaughtException(thread, error)
+        }
+        uncaughtHandlerInstalled = true
+    }
+
+    fun record(error: AppError) {
+        val entry = error.toDiagnosticEntry()
+        synchronized(lock) {
+            if (applicationContext == null) {
+                if (pending.size == MAX_PENDING_ENTRIES) pending.removeFirst()
+                pending.addLast(entry)
+            } else {
+                appendSafely(entry)
+            }
+        }
+    }
+
+    fun readText(): Result<String> = appResult(AppError.Kind.STORAGE, "Read diagnostics") {
+        synchronized(lock) {
+            val file = diagnosticsFile()
+            if (file.exists()) file.readText() else NO_DIAGNOSTICS
+        }
+    }
+
+    fun exportFile(): Result<File> = appResult(AppError.Kind.STORAGE, "Export diagnostics") {
+        synchronized(lock) {
+            diagnosticsFile().also { file ->
+                file.parentFile?.mkdirs()
+                if (!file.exists()) file.writeText(NO_DIAGNOSTICS)
+            }
+        }
+    }
+
+    fun clear(): Result<Unit> = appResult(AppError.Kind.STORAGE, "Clear diagnostics") {
+        synchronized(lock) {
+            val file = diagnosticsFile()
+            check(!file.exists() || file.delete()) { "Unable to delete diagnostics" }
+        }
+    }
+
+    private fun appendSafely(entry: String) {
+        try {
+            val file = diagnosticsFile()
+            file.parentFile?.mkdirs()
+            if (file.length() + entry.length > MAX_FILE_BYTES) rotate(file)
+            file.appendText(entry)
+        } catch (_: Throwable) {
+            // Diagnostics must never become a second failure source.
+        }
+    }
+
+    private fun rotate(file: File) {
+        val previous = File(file.parentFile, PREVIOUS_FILE_NAME)
+        if (previous.exists()) previous.delete()
+        if (file.exists()) file.renameTo(previous)
+    }
+
+    private fun diagnosticsFile(): File {
+        val context = checkNotNull(applicationContext) { "Diagnostics are not initialized" }
+        return File(File(context.filesDir, DIRECTORY_NAME), FILE_NAME)
+    }
+
+    private fun AppError.toDiagnosticEntry(): String = buildString {
+        val timestamp = SimpleDateFormat(TIMESTAMP_FORMAT, Locale.US).format(Date())
+        append(timestamp).append(" | ").append(kind).append(" | ").append(operation).appendLine()
+        append(stackTraceToString().take(MAX_ENTRY_CHARS)).appendLine()
+        appendLine(ENTRY_SEPARATOR)
+    }
+
+    private const val DIRECTORY_NAME = "diagnostics"
+    private const val FILE_NAME = "sensorbox-diagnostics.txt"
+    private const val PREVIOUS_FILE_NAME = "sensorbox-diagnostics-previous.txt"
+    private const val TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    private const val ENTRY_SEPARATOR = "---"
+    private const val NO_DIAGNOSTICS = "No diagnostics have been recorded.\n"
+    private const val MAX_PENDING_ENTRIES = 20
+    private const val MAX_ENTRY_CHARS = 32_000
+    private const val MAX_FILE_BYTES = 1_000_000L
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/error/AppError.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/error/AppError.kt
@@ -1,0 +1,73 @@
+package com.motionapps.sensorbox.core.error
+
+import kotlinx.coroutines.CancellationException
+
+class AppError(val kind: Kind, val operation: String, cause: Throwable? = null) :
+    Exception(message(operation, cause), cause) {
+    init {
+        AppDiagnostics.record(this)
+    }
+
+    enum class Kind {
+        CONNECTIVITY,
+        EXTERNAL_ACTION,
+        MEASUREMENT,
+        PERMISSION,
+        PREFERENCES,
+        STORAGE,
+        UNKNOWN,
+    }
+
+    companion object {
+        fun from(kind: Kind, operation: String, cause: Throwable): AppError =
+            cause as? AppError ?: AppError(kind, operation, cause)
+
+        private fun message(operation: String, cause: Throwable?): String =
+            cause?.message?.takeIf(String::isNotBlank)?.let { "$operation: $it" } ?: "$operation failed"
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+inline fun <T> appResult(kind: AppError.Kind, operation: String, block: () -> T): Result<T> = try {
+    Result.success(block())
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Throwable) {
+    Result.failure(AppError.from(kind, operation, error))
+}
+
+@Suppress("TooGenericExceptionCaught")
+suspend inline fun <T> suspendAppResult(
+    kind: AppError.Kind,
+    operation: String,
+    crossinline block: suspend () -> T,
+): Result<T> = try {
+    Result.success(block())
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Throwable) {
+    Result.failure(AppError.from(kind, operation, error))
+}
+
+fun <T> Result<T>.withAppError(kind: AppError.Kind, operation: String): Result<T> = fold(
+    onSuccess = Result.Companion::success,
+    onFailure = { Result.failure(AppError.from(kind, operation, it)) },
+)
+
+inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>): Result<R> = fold(
+    onSuccess = transform,
+    onFailure = Result.Companion::failure,
+)
+
+suspend inline fun <T, R> Result<T>.suspendFlatMap(crossinline transform: suspend (T) -> Result<R>): Result<R> = fold(
+    onSuccess = { transform(it) },
+    onFailure = Result.Companion::failure,
+)
+
+fun Iterable<Result<*>>.combineAppResults(kind: AppError.Kind, operation: String): Result<Unit> {
+    val failures = mapNotNull(Result<*>::exceptionOrNull)
+    if (failures.isEmpty()) return Result.success(Unit)
+    val first = failures.first()
+    failures.drop(1).forEach(first::addSuppressed)
+    return Result.failure(AppError.from(kind, operation, first))
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferences.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferences.kt
@@ -1,0 +1,13 @@
+package com.motionapps.sensorbox.core.preferences
+
+data class AppPreferences(
+    val hasCompletedIntro: Boolean = false,
+    val hasAcceptedPolicy: Boolean = false,
+    val gpsIntervalSeconds: Int = 10,
+    val gpsMinDistanceMeters: Int = 20,
+    val sensorSamplingPeriod: Int = 0,
+    val restrictMeasurementOnLowBattery: Boolean = true,
+    val useWakeLock: Boolean = false,
+    val keepPhoneDisplayOn: Boolean = false,
+    val keepWearDisplayOn: Boolean = false,
+)

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesDataStoreFactory.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesDataStoreFactory.kt
@@ -1,0 +1,15 @@
+package com.motionapps.sensorbox.core.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+
+object AppPreferencesDataStoreFactory {
+    fun create(context: Context): DataStore<Preferences> = PreferenceDataStoreFactory.create(
+        produceFile = { context.preferencesDataStoreFile(FILE_NAME) },
+    )
+
+    private const val FILE_NAME = "sensorbox"
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesIntent.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesIntent.kt
@@ -1,0 +1,21 @@
+package com.motionapps.sensorbox.core.preferences
+
+sealed interface AppPreferencesIntent {
+    data object CompleteIntro : AppPreferencesIntent
+
+    data object AcceptPolicy : AppPreferencesIntent
+
+    data class SetGpsInterval(val seconds: Int) : AppPreferencesIntent
+
+    data class SetGpsMinDistance(val meters: Int) : AppPreferencesIntent
+
+    data class SetSensorSamplingPeriod(val period: Int) : AppPreferencesIntent
+
+    data class SetLowBatteryRestriction(val enabled: Boolean) : AppPreferencesIntent
+
+    data class SetWakeLock(val enabled: Boolean) : AppPreferencesIntent
+
+    data class SetKeepPhoneDisplayOn(val enabled: Boolean) : AppPreferencesIntent
+
+    data class SetKeepWearDisplayOn(val enabled: Boolean) : AppPreferencesIntent
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesReducer.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesReducer.kt
@@ -1,0 +1,35 @@
+package com.motionapps.sensorbox.core.preferences
+
+object AppPreferencesReducer {
+    fun reduce(current: AppPreferences, intent: AppPreferencesIntent): AppPreferences = when (intent) {
+        AppPreferencesIntent.AcceptPolicy -> current.copy(hasAcceptedPolicy = true)
+
+        AppPreferencesIntent.CompleteIntro -> current.copy(hasCompletedIntro = true)
+
+        is AppPreferencesIntent.SetGpsInterval -> current.copy(
+            gpsIntervalSeconds = intent.seconds.coerceAtLeast(1),
+        )
+
+        is AppPreferencesIntent.SetGpsMinDistance -> current.copy(
+            gpsMinDistanceMeters = intent.meters.coerceAtLeast(0),
+        )
+
+        is AppPreferencesIntent.SetKeepWearDisplayOn -> current.copy(
+            keepWearDisplayOn = intent.enabled,
+        )
+
+        is AppPreferencesIntent.SetKeepPhoneDisplayOn -> current.copy(
+            keepPhoneDisplayOn = intent.enabled,
+        )
+
+        is AppPreferencesIntent.SetLowBatteryRestriction -> current.copy(
+            restrictMeasurementOnLowBattery = intent.enabled,
+        )
+
+        is AppPreferencesIntent.SetSensorSamplingPeriod -> current.copy(
+            sensorSamplingPeriod = intent.period,
+        )
+
+        is AppPreferencesIntent.SetWakeLock -> current.copy(useWakeLock = intent.enabled)
+    }
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesRepository.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/AppPreferencesRepository.kt
@@ -1,0 +1,9 @@
+package com.motionapps.sensorbox.core.preferences
+
+import kotlinx.coroutines.flow.Flow
+
+interface AppPreferencesRepository {
+    val preferences: Flow<Result<AppPreferences>>
+
+    suspend fun dispatch(intent: AppPreferencesIntent): Result<Unit>
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/preferences/DataStoreAppPreferencesRepository.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/preferences/DataStoreAppPreferencesRepository.kt
@@ -1,0 +1,68 @@
+package com.motionapps.sensorbox.core.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.suspendAppResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DataStoreAppPreferencesRepository(private val dataStore: DataStore<Preferences>) : AppPreferencesRepository {
+    override val preferences: Flow<Result<AppPreferences>> = dataStore.data
+        .map { values -> Result.success(values.toAppPreferences()) }
+        .catch { error ->
+            if (error is CancellationException) throw error
+            emit(Result.failure(AppError.from(AppError.Kind.PREFERENCES, "Read preferences", error)))
+        }
+
+    override suspend fun dispatch(intent: AppPreferencesIntent): Result<Unit> = suspendAppResult(
+        AppError.Kind.PREFERENCES,
+        "Update preferences",
+    ) {
+        dataStore.edit { values ->
+            val updated = AppPreferencesReducer.reduce(values.toAppPreferences(), intent)
+            values.write(updated)
+        }
+    }
+
+    private fun Preferences.toAppPreferences(): AppPreferences = AppPreferences(
+        hasCompletedIntro = this[Keys.COMPLETED_INTRO] ?: false,
+        hasAcceptedPolicy = this[Keys.ACCEPTED_POLICY] ?: false,
+        gpsIntervalSeconds = this[Keys.GPS_INTERVAL] ?: 10,
+        gpsMinDistanceMeters = this[Keys.GPS_DISTANCE] ?: 20,
+        sensorSamplingPeriod = this[Keys.SAMPLING_PERIOD] ?: 0,
+        restrictMeasurementOnLowBattery = this[Keys.LOW_BATTERY] ?: true,
+        useWakeLock = this[Keys.WAKE_LOCK] ?: false,
+        keepPhoneDisplayOn = this[Keys.KEEP_PHONE_DISPLAY_ON] ?: false,
+        keepWearDisplayOn = this[Keys.KEEP_DISPLAY_ON] ?: false,
+    )
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.write(value: AppPreferences) {
+        this[Keys.COMPLETED_INTRO] = value.hasCompletedIntro
+        this[Keys.ACCEPTED_POLICY] = value.hasAcceptedPolicy
+        this[Keys.GPS_INTERVAL] = value.gpsIntervalSeconds
+        this[Keys.GPS_DISTANCE] = value.gpsMinDistanceMeters
+        this[Keys.SAMPLING_PERIOD] = value.sensorSamplingPeriod
+        this[Keys.LOW_BATTERY] = value.restrictMeasurementOnLowBattery
+        this[Keys.WAKE_LOCK] = value.useWakeLock
+        this[Keys.KEEP_PHONE_DISPLAY_ON] = value.keepPhoneDisplayOn
+        this[Keys.KEEP_DISPLAY_ON] = value.keepWearDisplayOn
+    }
+
+    private object Keys {
+        val COMPLETED_INTRO = booleanPreferencesKey("completed_intro")
+        val ACCEPTED_POLICY = booleanPreferencesKey("accepted_policy")
+        val GPS_INTERVAL = intPreferencesKey("gps_interval_seconds")
+        val GPS_DISTANCE = intPreferencesKey("gps_min_distance_meters")
+        val SAMPLING_PERIOD = intPreferencesKey("sensor_sampling_period")
+        val LOW_BATTERY = booleanPreferencesKey("restrict_on_low_battery")
+        val WAKE_LOCK = booleanPreferencesKey("use_wake_lock")
+        val KEEP_PHONE_DISPLAY_ON = booleanPreferencesKey("keep_phone_display_on")
+        val KEEP_DISPLAY_ON = booleanPreferencesKey("keep_wear_display_on")
+    }
+}

--- a/core/src/main/java/com/motionapps/sensorbox/core/storage/NativeDocumentStorage.kt
+++ b/core/src/main/java/com/motionapps/sensorbox/core/storage/NativeDocumentStorage.kt
@@ -1,0 +1,184 @@
+package com.motionapps.sensorbox.core.storage
+
+import android.content.Context
+import android.content.Intent
+import androidx.documentfile.provider.DocumentFile
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+import com.motionapps.sensorbox.core.error.flatMap
+import java.io.InputStream
+import java.io.OutputStream
+
+object NativeDocumentStorage {
+    fun persistRootAccess(context: Context, intent: Intent, appDirectoryName: String): Result<Unit> {
+        val uri = intent.data ?: return storageFailure("Storage directory was not selected")
+        val grantFlags = intent.flags and READ_WRITE_FLAGS
+        if (grantFlags == 0) return storageFailure("Storage permission was not granted")
+        return appResult(AppError.Kind.STORAGE, "Persist storage permission") {
+            context.contentResolver.takePersistableUriPermission(uri, grantFlags)
+            DocumentFile.fromTreeUri(context, uri)
+        }.flatMap { selectedDirectory ->
+            if (selectedDirectory?.isDirectory != true) {
+                return@flatMap storageFailure("Selected storage location is not a directory")
+            }
+            releaseOtherRootPermissions(context, uri)
+            if (appDirectory(context, appDirectoryName, create = true) == null) {
+                storageFailure("Storage directory is unavailable")
+            } else {
+                Result.success(Unit)
+            }
+        }
+    }
+
+    fun hasAppDirectory(context: Context, appDirectoryName: String): Result<Boolean> = appResult(
+        AppError.Kind.STORAGE,
+        "Check storage directory",
+    ) {
+        appDirectory(context, appDirectoryName, create = false)?.exists() == true
+    }
+
+    fun displayPath(context: Context, appDirectoryName: String): Result<String?> = appResult(
+        AppError.Kind.STORAGE,
+        "Read storage path",
+    ) {
+        val selectedDirectory = appDirectory(context, appDirectoryName, create = false) ?: return@appResult null
+        selectedDirectory.name ?: selectedDirectory.uri.lastPathSegment
+    }
+
+    fun createMeasurementDirectory(context: Context, appDirectoryName: String, measurementName: String): Result<Unit> =
+        appResult(AppError.Kind.STORAGE, "Access measurement root") {
+            appDirectory(context, appDirectoryName, create = false)
+        }.flatMap { appDirectory ->
+            if (appDirectory == null) return@flatMap storageFailure("Storage directory is not configured")
+            appResult(AppError.Kind.STORAGE, "Create measurement directory") {
+                findDirectory(appDirectory, measurementName) != null ||
+                    appDirectory.createDirectory(measurementName) != null
+            }.flatMap { created ->
+                if (created) Result.success(Unit) else storageFailure("Unable to create measurement directory")
+            }
+        }
+
+    fun openMeasurementFile(
+        context: Context,
+        appDirectoryName: String,
+        measurementName: String,
+        mimeType: String,
+        fileName: String,
+        replaceExisting: Boolean = false,
+    ): Result<OutputStream> = appResult(AppError.Kind.STORAGE, "Access measurement directory") {
+        measurementDirectory(context, appDirectoryName, measurementName)
+    }.flatMap { directory ->
+        if (directory == null) return@flatMap storageFailure("Measurement directory is unavailable")
+        createOrReplaceFile(directory, mimeType, fileName, replaceExisting).flatMap { createdFile ->
+            if (createdFile == null) return@flatMap storageFailure("Unable to create measurement file")
+            appResult(AppError.Kind.STORAGE, "Open measurement file") {
+                context.contentResolver.openOutputStream(createdFile.uri, "wt")
+            }.flatMap { output ->
+                output?.let(Result.Companion::success) ?: storageFailure("Unable to open measurement file")
+            }
+        }
+    }
+
+    fun deleteMeasurement(context: Context, appDirectoryName: String, measurementName: String): Result<Unit> =
+        appResult(AppError.Kind.STORAGE, "Access measurement directory") {
+            appDirectory(context, appDirectoryName, create = false)
+        }.flatMap { appDirectory ->
+            if (appDirectory == null) return@flatMap storageFailure("Storage directory is not configured")
+            val directory = findDirectory(appDirectory, measurementName)
+                ?: return@flatMap storageFailure("Measurement does not exist")
+            appResult(AppError.Kind.STORAGE, "Delete measurement") { directory.delete() }.flatMap { deleted ->
+                if (deleted) Result.success(Unit) else storageFailure("Unable to delete measurement")
+            }
+        }
+
+    fun copyToMeasurement(
+        context: Context,
+        input: InputStream,
+        appDirectoryName: String,
+        measurementName: String,
+        fileName: String,
+        mimeType: String,
+    ): Result<Unit> = openMeasurementFile(
+        context = context,
+        appDirectoryName = appDirectoryName,
+        measurementName = measurementName,
+        mimeType = mimeType,
+        fileName = fileName,
+        replaceExisting = true,
+    ).flatMap { output ->
+        appResult(AppError.Kind.STORAGE, "Copy measurement file") {
+            input.use { source -> output.use(source::copyTo) }
+            Unit
+        }
+    }
+
+    private fun measurementDirectory(
+        context: Context,
+        appDirectoryName: String,
+        measurementName: String,
+    ): DocumentFile? {
+        val appDirectory = appDirectory(context, appDirectoryName, create = false) ?: return null
+        return findDirectory(appDirectory, measurementName)
+            ?: appDirectory.createDirectory(measurementName)
+    }
+
+    private fun appDirectory(
+        context: Context,
+        @Suppress("UNUSED_PARAMETER") directoryName: String,
+        @Suppress("UNUSED_PARAMETER") create: Boolean,
+    ): DocumentFile? = persistedRoot(context)?.takeIf(DocumentFile::isDirectory)
+
+    private fun persistedRoot(context: Context): DocumentFile? {
+        val permission = context.contentResolver.persistedUriPermissions
+            .filter { it.isReadPermission && it.isWritePermission }
+            .maxByOrNull { it.persistedTime }
+            ?: return null
+        return DocumentFile.fromTreeUri(context, permission.uri)
+    }
+
+    private fun findDirectory(parent: DocumentFile, name: String): DocumentFile? =
+        parent.findFile(name)?.takeIf(DocumentFile::isDirectory)
+
+    private const val READ_WRITE_FLAGS =
+        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+}
+
+private fun createOrReplaceFile(
+    directory: DocumentFile,
+    mimeType: String,
+    fileName: String,
+    replaceExisting: Boolean,
+): Result<DocumentFile?> = appResult(AppError.Kind.STORAGE, "Create measurement file") {
+    val existing = directory.findFile(fileName)
+    if (replaceExisting && existing != null) {
+        if (existing.delete()) directory.createFile(normalizeMimeType(mimeType), fileName) else null
+    } else {
+        existing ?: directory.createFile(normalizeMimeType(mimeType), fileName)
+    }
+}
+
+private fun <T> storageFailure(operation: String): Result<T> =
+    Result.failure(AppError(AppError.Kind.STORAGE, operation))
+
+private fun releaseOtherRootPermissions(context: Context, selectedUri: android.net.Uri) {
+    val resolver = context.contentResolver
+    resolver.persistedUriPermissions
+        .filter { it.uri != selectedUri }
+        .forEach { permission ->
+            val flags =
+                (if (permission.isReadPermission) Intent.FLAG_GRANT_READ_URI_PERMISSION else 0) or
+                    (if (permission.isWritePermission) Intent.FLAG_GRANT_WRITE_URI_PERMISSION else 0)
+            if (flags != 0) {
+                appResult(AppError.Kind.STORAGE, "Release old storage permission") {
+                    resolver.releasePersistableUriPermission(permission.uri, flags)
+                }
+            }
+        }
+}
+
+private fun normalizeMimeType(value: String): String = when (value.lowercase()) {
+    "csv" -> "text/csv"
+    "json" -> "application/json"
+    "txt" -> "text/plain"
+    else -> value.takeIf { '/' in it } ?: "application/octet-stream"
+}

--- a/core/src/test/java/com/motionapps/sensorbox/core/error/AppErrorTest.kt
+++ b/core/src/test/java/com/motionapps/sensorbox/core/error/AppErrorTest.kt
@@ -1,0 +1,32 @@
+package com.motionapps.sensorbox.core.error
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppErrorTest {
+    @Test
+    fun `Given an operation failure When captured Then AppError is returned`() {
+        val cause = IllegalStateException("disk unavailable")
+
+        val result = appResult(AppError.Kind.STORAGE, "Write file") { throw cause }
+
+        val error = result.exceptionOrNull()
+        assertTrue(error is AppError)
+        assertEquals(AppError.Kind.STORAGE, (error as AppError).kind)
+        assertEquals("Write file", error.operation)
+        assertSame(cause, error.cause)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `Given coroutine cancellation When captured Then cancellation is rethrown`() {
+        runBlocking {
+            suspendAppResult<Unit>(AppError.Kind.CONNECTIVITY, "Send message") {
+                throw CancellationException("cancelled")
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/motionapps/sensorbox/core/preferences/AppPreferencesReducerTest.kt
+++ b/core/src/test/java/com/motionapps/sensorbox/core/preferences/AppPreferencesReducerTest.kt
@@ -1,0 +1,56 @@
+package com.motionapps.sensorbox.core.preferences
+
+import com.motionapps.sensorbox.core.testing.AppPreferencesFixtures
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppPreferencesReducerTest {
+    @Test
+    fun `Given fresh preferences When intro completes Then completion is retained`() {
+        val givenPreferences = AppPreferencesFixtures.preferences()
+
+        val actual = AppPreferencesReducer.reduce(
+            current = givenPreferences,
+            intent = AppPreferencesIntent.CompleteIntro,
+        )
+
+        assertTrue(actual.hasCompletedIntro)
+    }
+
+    @Test
+    fun `Given any preferences When invalid GPS interval is submitted Then it is clamped`() {
+        val givenPreferences = AppPreferencesFixtures.preferences(gpsIntervalSeconds = 10)
+
+        val actual = AppPreferencesReducer.reduce(
+            current = givenPreferences,
+            intent = AppPreferencesIntent.SetGpsInterval(seconds = 0),
+        )
+
+        assertEquals(1, actual.gpsIntervalSeconds)
+    }
+
+    @Test
+    fun `Given battery protection enabled When disabled Then the preference changes`() {
+        val givenPreferences = AppPreferencesFixtures.preferences().copy(restrictMeasurementOnLowBattery = true)
+
+        val actual = AppPreferencesReducer.reduce(
+            current = givenPreferences,
+            intent = AppPreferencesIntent.SetLowBatteryRestriction(false),
+        )
+
+        assertEquals(false, actual.restrictMeasurementOnLowBattery)
+    }
+
+    @Test
+    fun `Given screen awake disabled When enabled Then the preference changes`() {
+        val givenPreferences = AppPreferencesFixtures.preferences().copy(keepPhoneDisplayOn = false)
+
+        val actual = AppPreferencesReducer.reduce(
+            current = givenPreferences,
+            intent = AppPreferencesIntent.SetKeepPhoneDisplayOn(true),
+        )
+
+        assertTrue(actual.keepPhoneDisplayOn)
+    }
+}

--- a/core/src/testFixtures/java/com/motionapps/sensorbox/core/testing/AppPreferencesFixtures.kt
+++ b/core/src/testFixtures/java/com/motionapps/sensorbox/core/testing/AppPreferencesFixtures.kt
@@ -1,0 +1,10 @@
+package com.motionapps.sensorbox.core.testing
+
+import com.motionapps.sensorbox.core.preferences.AppPreferences
+
+object AppPreferencesFixtures {
+    fun preferences(gpsIntervalSeconds: Int = 10, gpsMinDistanceMeters: Int = 20): AppPreferences = AppPreferences(
+        gpsIntervalSeconds = gpsIntervalSeconds,
+        gpsMinDistanceMeters = gpsMinDistanceMeters,
+    )
+}

--- a/core/src/testFixtures/java/com/motionapps/sensorbox/core/testing/FakeAppPreferencesRepository.kt
+++ b/core/src/testFixtures/java/com/motionapps/sensorbox/core/testing/FakeAppPreferencesRepository.kt
@@ -1,0 +1,21 @@
+package com.motionapps.sensorbox.core.testing
+
+import com.motionapps.sensorbox.core.preferences.AppPreferences
+import com.motionapps.sensorbox.core.preferences.AppPreferencesIntent
+import com.motionapps.sensorbox.core.preferences.AppPreferencesReducer
+import com.motionapps.sensorbox.core.preferences.AppPreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class FakeAppPreferencesRepository(
+    initial: AppPreferences = AppPreferences(),
+) : AppPreferencesRepository {
+    private val mutablePreferences = MutableStateFlow(initial)
+
+    override val preferences = mutablePreferences.map(Result.Companion::success)
+
+    override suspend fun dispatch(intent: AppPreferencesIntent): Result<Unit> {
+        mutablePreferences.value = AppPreferencesReducer.reduce(mutablePreferences.value, intent)
+        return Result.success(Unit)
+    }
+}


### PR DESCRIPTION
Architecture stack 1 of 39.

Base: `master`
Head: `architecture/01-core-foundations`
Changed lines in this layer: 649.

This layer introduces the shared core foundations. Review this PR first, then continue through the numbered stack. Each later PR targets the branch immediately before it, so GitHub shows only that layer.

Stack navigation: previous `master`; next #61.