### PR TITLE
[06/39] refactor(sensorservice): modernize service runtime

### DIFF
--- a/sensorservices/src/main/java/com/motionapps/sensorservices/serviceController/MeasurementConfig.kt
+++ b/sensorservices/src/main/java/com/motionapps/sensorservices/serviceController/MeasurementConfig.kt
@@ -1,0 +1,59 @@
+package com.motionapps.sensorservices.serviceController
+
+import android.content.Intent
+import android.hardware.SensorManager
+import com.motionapps.sensorservices.services.MeasurementService
+
+data class MeasurementConfig(
+    val folderName: String,
+    val useInternalStorage: Boolean,
+    val sensorIds: IntArray,
+    val sensorSamplingPeriod: Int,
+    val includesGps: Boolean,
+    val stopOnLowBattery: Boolean,
+    val useWakeLock: Boolean,
+    val gpsIntervalSeconds: Int,
+    val gpsMinDistanceMeters: Int,
+    val measurementType: String,
+    val startAtEpochMillis: Long,
+    val durationMillis: Long,
+    val notes: List<String>,
+    val alarmOffsetsSeconds: List<Int>,
+    val activityRecognition: Boolean,
+    val activityRecognitionPeriodSeconds: Int,
+    val significantMotion: Boolean,
+    val controlsWearMeasurement: Boolean,
+) {
+    companion object {
+        fun from(intent: Intent): MeasurementConfig = MeasurementConfig(
+            folderName = intent.getStringExtra(MeasurementService.FOLDER_NAME).orEmpty(),
+            useInternalStorage = intent.getBooleanExtra(MeasurementService.INTERNAL_STORAGE, false),
+            sensorIds = intent.getIntArrayExtra(MeasurementService.ANDROID_SENSORS) ?: intArrayOf(),
+            sensorSamplingPeriod = intent.getIntExtra(
+                MeasurementService.ANDROID_SENSORS_SPEED,
+                SensorManager.SENSOR_DELAY_FASTEST,
+            ),
+            includesGps = intent.getBooleanExtra(MeasurementService.GPS, false),
+            stopOnLowBattery = intent.getBooleanExtra(MeasurementService.STOP_ON_LOW_BATTERY, false),
+            useWakeLock = intent.getBooleanExtra(MeasurementService.USE_WAKE_LOCK, false),
+            gpsIntervalSeconds = intent.getIntExtra(MeasurementService.GPS_INTERVAL_SECONDS, 10),
+            gpsMinDistanceMeters = intent.getIntExtra(MeasurementService.GPS_DISTANCE_METERS, 20),
+            measurementType = intent.getStringExtra(MeasurementService.MEASUREMENT_TYPE) ?: "ENDLESS",
+            startAtEpochMillis = intent.getLongExtra(
+                MeasurementService.START_AT_EPOCH_MILLIS,
+                System.currentTimeMillis(),
+            ),
+            durationMillis = intent.getLongExtra(MeasurementService.DURATION_MILLIS, 0L).coerceAtLeast(0L),
+            notes = intent.getStringArrayListExtra(MeasurementService.NOTES).orEmpty(),
+            alarmOffsetsSeconds = intent.getIntArrayExtra(MeasurementService.ALARM_OFFSETS_SECONDS)
+                ?.filter { it >= 0 }.orEmpty(),
+            activityRecognition = intent.getBooleanExtra(MeasurementService.ACTIVITY_RECOGNITION, false),
+            activityRecognitionPeriodSeconds = intent.getIntExtra(
+                MeasurementService.ACTIVITY_RECOGNITION_PERIOD_SECONDS,
+                30,
+            ).coerceAtLeast(1),
+            significantMotion = intent.getBooleanExtra(MeasurementService.SIGNIFICANT_MOTION, false),
+            controlsWearMeasurement = intent.getBooleanExtra(MeasurementService.CONTROLS_WEAR_MEASUREMENT, false),
+        )
+    }
+}

--- a/sensorservices/src/main/java/com/motionapps/sensorservices/serviceController/ServiceController.kt
+++ b/sensorservices/src/main/java/com/motionapps/sensorservices/serviceController/ServiceController.kt
@@ -1,261 +1,124 @@
 package com.motionapps.sensorservices.serviceController
 
-import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.hardware.SensorManager
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
+import android.media.AudioManager
+import android.media.ToneGenerator
 import android.os.Bundle
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+import com.motionapps.sensorbox.core.error.combineAppResults
+import com.motionapps.sensorbox.core.error.flatMap
+import com.motionapps.sensorbox.core.error.withAppError
 import com.motionapps.sensorservices.handlers.GPSHandler
 import com.motionapps.sensorservices.handlers.StorageHandler
-import com.motionapps.sensorservices.handlers.measurements.ActivityRecognition
-import com.motionapps.sensorservices.handlers.measurements.AlarmNoiseHandler
+import com.motionapps.sensorservices.handlers.measurements.ActivityRecognitionMeasurement
 import com.motionapps.sensorservices.handlers.measurements.ExtraInfoHandler
 import com.motionapps.sensorservices.handlers.measurements.GPSMeasurement
 import com.motionapps.sensorservices.handlers.measurements.MeasurementInterface
 import com.motionapps.sensorservices.handlers.measurements.SensorMeasurement
 import com.motionapps.sensorservices.handlers.measurements.SignificantMotion
 import com.motionapps.sensorservices.services.MeasurementService
-import com.motionapps.sensorservices.services.MeasurementStates
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 
-
-@ExperimentalCoroutinesApi
-@InternalCoroutinesApi
-/**
- * handles all the interactions of the service and controls the flow of the measurement
- *
- */
 class ServiceController {
+    private val sensorMeasurement = SensorMeasurement()
+    private val gpsMeasurement = GPSMeasurement(GPSHandler())
+    private var activeConfig: MeasurementConfig? = null
+    private val extraInfo = ExtraInfoHandler()
+    private var activityRecognition: ActivityRecognitionMeasurement? = null
+    private val significantMotion = SignificantMotion()
+    private var toneGenerator: ToneGenerator? = null
 
-    // all handles in one place
-    private val activityRecognition: ActivityRecognition = ActivityRecognition()
-    private val alarmNoiseHandler: AlarmNoiseHandler = AlarmNoiseHandler()
-    private val extraInfoHandler: ExtraInfoHandler = ExtraInfoHandler()
-    private val gpsMeasurement: GPSMeasurement = GPSMeasurement(GPSHandler())
-    private val sensorMeasurement: SensorMeasurement = SensorMeasurement()
-    private val significantMotion: SignificantMotion = SignificantMotion()
-
-    // basic parameters to use in service
-    private var paramType: Int = MeasurementService.ENDLESS
-    private var paramSensorId: IntArray? = null
-    private var paramTimeIntervals: IntArray = intArrayOf(-1)
-    private var paramChecks: BooleanArray = booleanArrayOf(false, false, false, false, false)
-
-    private var paramFolderName = ""
-    private var paramInternalStorage = false
-    private var paramSensorSpeed: Int = SensorManager.SENSOR_DELAY_FASTEST
-    private var paramGPSToMeasure: Boolean = false
-
-    /**
-     * on first run
-     * get data from the intent and unpack it
-     *
-     * @param context
-     * @param intent - unpack to fill parameters for the measurement
-     */
-    fun onInit(context: Context, intent: Intent?){
-
-        intent?.let {
-            it.extras?.let{b ->
-
-                paramFolderName = b.getString(MeasurementService.FOLDER_NAME, "")
-                paramInternalStorage = b.getBoolean(MeasurementService.INTERNAL_STORAGE, false)
-                paramSensorId = b.getIntArray(MeasurementService.ANDROID_SENSORS)
-                paramSensorSpeed = b.getInt(MeasurementService.ANDROID_SENSORS_SPEED, SensorManager.SENSOR_DELAY_FASTEST)
-                paramType = b.getInt(MeasurementService.TYPE, MeasurementService.ENDLESS)
-                paramTimeIntervals = b.getIntArray(MeasurementService.TIME_INTERVALS)!!
-                paramGPSToMeasure = b.getBoolean(MeasurementService.GPS, false)
-                paramChecks = b.getBooleanArray(MeasurementService.OTHER)!!
-
-                extraInfoHandler.onStart(context, paramInternalStorage) // init of the notes and alarms
-                extraInfoHandler.handleNotes(b.getStringArrayList(MeasurementService.NOTES))
+    fun start(context: Context, config: MeasurementConfig): Result<Unit> {
+        var result = createMeasurementDirectory(context, config).flatMap {
+            appResult(AppError.Kind.MEASUREMENT, "Initialize measurement session") {
+                activeConfig = config
+                extraInfo.start(config)
             }
         }
+        if (config.sensorIds.isNotEmpty()) result = result.flatMap { startSensors(context, config) }
+        if (config.includesGps) result = result.flatMap { startGps(context, config) }
+        if (config.activityRecognition) result = result.flatMap { startActivityRecognition(context, config) }
+        if (config.significantMotion) result = result.flatMap { startSignificantMotion(context, config) }
+        return result.withAppError(AppError.Kind.MEASUREMENT, "Start measurement controller")
     }
 
-    /**
-     * Stores annotation to handler
-     *
-     * @param time - milliseconds
-     * @param text - text of the annotation
-     */
-    fun onAnnotation(time: Long, text: String) {
-        extraInfoHandler.writeAnnotation(time, text)
+    suspend fun stop(context: Context): Result<Unit> {
+        val config = activeConfig ?: return Result.success(Unit)
+        val results = mutableListOf<Result<*>>()
+        if (config.sensorIds.isNotEmpty()) results += sensorMeasurement.onDestroyMeasurement(context)
+        if (config.includesGps) results += gpsMeasurement.onDestroyMeasurement(context)
+        activityRecognition?.let { results += it.onDestroyMeasurement(context) }
+        activityRecognition = null
+        if (config.significantMotion) results += significantMotion.onDestroyMeasurement(context)
+        results += appResult(AppError.Kind.MEASUREMENT, "Release alarm") {
+            toneGenerator?.release()
+            Unit
+        }
+        toneGenerator = null
+        results += extraInfo.write(context)
+        activeConfig = null
+        return results.combineAppResults(AppError.Kind.MEASUREMENT, "Stop measurement controller")
     }
 
-    /**
-     * passes parameters to handlers and starts all the measurements
-     *
-     * @param context
-     * @return
-     */
-    fun onStart(context: Context): Boolean {
-        val date = StorageHandler.getDate(System.currentTimeMillis(), "dd_MM_yyyy_HH_mm_ss")
-
-        val measurement = when(paramType){
-            MeasurementService.SHORT -> MeasurementService.SHORT_STRING
-//            MeasurementService.LONG -> MeasurementService.LONG_STRING
-            else -> MeasurementService.ENDLESS_STRING
-        }
-
-        extraInfoHandler.folderName = paramFolderName
-        extraInfoHandler.date = date
-        extraInfoHandler.measurementType = measurement
-
-        if(paramInternalStorage) {
-            if (!StorageHandler.createInternalStorageMeasurementFolder(context, paramFolderName)) {
-                return false
-            }
-        }else{
-            if (!StorageHandler.createFolderMeasurement(context, paramFolderName)) {
-                return false
-            }
-        }
-
-        // Sensors
-        paramSensorId?.let {
-            val params: Bundle = Bundle().apply {
-                putString(MeasurementInterface.FOLDER_NAME, paramFolderName)
-                putBoolean(MeasurementInterface.INTERNAL_STORAGE, paramInternalStorage)
-                putIntArray(MeasurementInterface.SENSOR_ID, paramSensorId)
-                putInt(MeasurementInterface.SENSOR_SPEED, paramSensorSpeed)
-            }
-            sensorMeasurement.initMeasurement(context, params)
-            sensorMeasurement.startMeasurement(context)
-        }
-
-        // GPS
-        if(paramGPSToMeasure){
-            val params: Bundle = Bundle().apply {
-                putString(MeasurementInterface.FOLDER_NAME, paramFolderName)
-                putBoolean(MeasurementInterface.INTERNAL_STORAGE, paramInternalStorage)
-            }
-            gpsMeasurement.initMeasurement(context, params)
-            gpsMeasurement.startMeasurement(context)
-        }
-
-        // activity recognition
-        if(paramChecks[0]){
-            val params: Bundle = Bundle().apply {
-                putString(MeasurementInterface.FOLDER_NAME, paramFolderName)
-                putBoolean(MeasurementInterface.INTERNAL_STORAGE, paramInternalStorage)
-            }
-            activityRecognition.initMeasurement(context, params)
-            activityRecognition.startMeasurement(context)
-        }
-
-        // significant motion
-        if(paramChecks[1]){
-            val params: Bundle = Bundle().apply {
-                putString(MeasurementInterface.FOLDER_NAME, paramFolderName)
-                putBoolean(MeasurementInterface.INTERNAL_STORAGE, paramInternalStorage)
-            }
-            significantMotion.initMeasurement(context, params)
-            significantMotion.startMeasurement(context)
-        }
-
-        return true
+    fun annotate(timestampMillis: Long, text: String): Result<Unit> = appResult(
+        AppError.Kind.MEASUREMENT,
+        "Add measurement annotation",
+    ) {
+        extraInfo.annotate(timestampMillis, text)
     }
 
-    /**
-     * internal counter for the SHORT measurement based on flow and delay
-     *
-     */
-    suspend fun shortTimer() = flow {
+    fun playAlarm(): Result<Unit> = appResult(AppError.Kind.MEASUREMENT, "Play measurement alarm") {
+        extraInfo.alarmTriggered()
+        val tone = toneGenerator ?: ToneGenerator(AudioManager.STREAM_ALARM, 100).also { toneGenerator = it }
+        tone.startTone(ToneGenerator.TONE_CDMA_ALERT_CALL_GUARD, ALARM_DURATION_MILLIS)
+    }
 
-        for(i in paramTimeIntervals[1]-1 downTo 0){
-            delay(1000L)
-            alarmNoiseHandler.onShortTick(i*1000L)
-            emit(MeasurementStates.OnTick(i))
+    private fun createMeasurementDirectory(context: Context, config: MeasurementConfig): Result<Unit> =
+        if (config.useInternalStorage) {
+            StorageHandler.createInternalStorageMeasurementFolder(context, config.folderName)
+        } else {
+            StorageHandler.createFolderMeasurement(context, config.folderName)
         }
-        emit(MeasurementStates.OnShortEnd)
-    }
 
-//    /**
-//     * Sets intent with AlarmManager
-//     *
-//     * @param context
-//     */
-//    fun longTimer(context: Context){
-//
-//        val addedTime: Long = ((paramTimeIntervals[0]*3600 + paramTimeIntervals[1] * 60) * 1000).toLong()
-//        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-//        val pendingIntent: PendingIntent = getAlarmIntent(context)
-//
-//        if (SDK_INT >= Build.VERSION_CODES.M) {
-//            alarmManager.setExactAndAllowWhileIdle(
-//                AlarmManager.RTC_WAKEUP,
-//                System.currentTimeMillis() + addedTime, pendingIntent
-//            )
-//        } else {
-//            alarmManager.setExact(
-//                AlarmManager.RTC_WAKEUP,
-//                System.currentTimeMillis() + addedTime, pendingIntent
-//            )
-//        }
-//
-//        alarmNoiseHandler.setLongAlarms(context, alarmManager)
-//
-//    }
-
-    /**
-     * @param context
-     * @return creates intent to stop Service
-     */
-    private fun getAlarmIntent(context: Context): PendingIntent{
-        val intent = Intent(MeasurementService.STOP_SERVICE)
-        intent.flags = Intent.FLAG_RECEIVER_FOREGROUND
-
-        val flags =
-            if (SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
-        return PendingIntent.getBroadcast(
-            context, 50, intent,
-            flags
-        )
-    }
-
-    /**
-     * creates JSON and all the handler are saved into csv files
-     *
-     * @param context
-     */
-    suspend fun onStop(context: Context) {
-        extraInfoHandler.addAlarms(alarmNoiseHandler)
-        extraInfoHandler.writeExtra(context, paramInternalStorage)
-
-        val saving = CoroutineScope(Dispatchers.Main).launch {
-            sensorMeasurement.onDestroyMeasurement(context)
-            gpsMeasurement.onDestroyMeasurement(context)
-            activityRecognition.onDestroyMeasurement(context)
+    private fun startSensors(context: Context, config: MeasurementConfig): Result<Unit> {
+        val params = baseParams(config).apply {
+            putIntArray(MeasurementInterface.SENSOR_ID, config.sensorIds)
+            putInt(MeasurementInterface.SENSOR_SPEED, config.sensorSamplingPeriod)
         }
-        saving.join()
-//        if(paramType == MeasurementService.LONG){
-//            cancelAlarm(context)
-//        }
+        return sensorMeasurement.initMeasurement(context, params)
+            .flatMap { sensorMeasurement.startMeasurement(context) }
+            .withAppError(AppError.Kind.MEASUREMENT, "Start configured sensors")
     }
 
-    /**
-     * alarm is removed for Long measurement
-     *
-     * @param context
-     */
-    private fun cancelAlarm(context: Context){
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val pendingIntent: PendingIntent = getAlarmIntent(context)
-        alarmManager.cancel(pendingIntent)
-        alarmNoiseHandler.onDestroy()
+    private fun startGps(context: Context, config: MeasurementConfig): Result<Unit> {
+        val params = baseParams(config).apply {
+            putInt(MeasurementService.GPS_INTERVAL_SECONDS, config.gpsIntervalSeconds)
+            putInt(MeasurementService.GPS_DISTANCE_METERS, config.gpsMinDistanceMeters)
+        }
+        return gpsMeasurement.initMeasurement(context, params)
+            .flatMap { gpsMeasurement.startMeasurement(context) }
+            .withAppError(AppError.Kind.MEASUREMENT, "Start configured GPS")
+    }
+
+    private fun startActivityRecognition(context: Context, config: MeasurementConfig): Result<Unit> {
+        val handler = ActivityRecognitionMeasurement(config.activityRecognitionPeriodSeconds)
+        return handler.initMeasurement(context, baseParams(config))
+            .flatMap { handler.startMeasurement(context) }
+            .onSuccess { activityRecognition = handler }
+            .withAppError(AppError.Kind.MEASUREMENT, "Start configured activity recognition")
+    }
+
+    private fun startSignificantMotion(context: Context, config: MeasurementConfig): Result<Unit> =
+        significantMotion.initMeasurement(context, baseParams(config))
+            .flatMap { significantMotion.startMeasurement(context) }
+            .withAppError(AppError.Kind.MEASUREMENT, "Start configured significant motion")
+
+    private fun baseParams(config: MeasurementConfig) = Bundle().apply {
+        putString(MeasurementInterface.FOLDER_NAME, config.folderName)
+        putBoolean(MeasurementInterface.INTERNAL_STORAGE, config.useInternalStorage)
+    }
+
+    private companion object {
+        const val ALARM_DURATION_MILLIS = 1_000
     }
 }

--- a/sensorservices/src/main/java/com/motionapps/sensorservices/services/MeasurementService.kt
+++ b/sensorservices/src/main/java/com/motionapps/sensorservices/services/MeasurementService.kt
@@ -1,6 +1,5 @@
 package com.motionapps.sensorservices.services
 
-import android.annotation.SuppressLint
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -8,573 +7,258 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
-import android.hardware.SensorManager
-import android.os.*
-import com.motionapps.sensorservices.R
-import com.motionapps.sensorservices.handlers.StorageHandler
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import android.os.SystemClock
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+import com.motionapps.sensorbox.core.error.combineAppResults
+import com.motionapps.sensorbox.core.error.suspendFlatMap
+import com.motionapps.sensorservices.serviceController.MeasurementConfig
 import com.motionapps.sensorservices.serviceController.ServiceController
-import com.motionapps.wearoslib.WearOsConstants
-import com.motionapps.wearoslib.WearOsHandler
-import com.motionapps.wearoslib.WearOsListener
-import com.motionapps.wearoslib.WearOsStates
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import com.motionapps.sensorservices.session.MeasurementSessionState
+import com.motionapps.sensorservices.session.MeasurementSessionStore
+import com.motionapps.wearoslib.WearOsConstants.WEAR_APP_CAPABILITY
+import com.motionapps.wearoslib.WearOsConstants.WEAR_MESSAGE_PATH
+import com.motionapps.wearoslib.connectivity.SendWearMessageUseCase
+import com.motionapps.wearoslib.protocol.WearCommand
+import com.motionapps.wearoslib.protocol.WearCommandCodec
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-@ExperimentalCoroutinesApi
-@InternalCoroutinesApi
-class MeasurementService : Service(), WearOsListener {
+@AndroidEntryPoint
+class MeasurementService : Service() {
+    @Inject
+    lateinit var sessionStore: MeasurementSessionStore
 
+    @Inject
+    lateinit var sendWearMessage: SendWearMessageUseCase
 
-    private val serviceBroadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context?, intent: Intent?) {
-
-            if (intent != null) {
-                // stops service and pending intent to stop, or on low battery
-                if (intent.action == STOP_SERVICE || intent.action == Intent.ACTION_BATTERY_LOW) {
-                    if (!intent.getBooleanExtra(USER, false)) {
-                        sendOnFinishNotification()
-                    }
-                    context?.sendBroadcast(Intent(STOP_ACTIVITY))
-                    cancelService()
-
-                } else if (intent.action == ANNOTATION) { // to pass annotation from the measurementActivity
-                    intent.extras?.let {
-                        val time: Long = it.getLong(ANNOTATION_TIME, -1L)
-                        val text: String = it.getString(ANNOTATION_TEXT, "")
-                        if (time != -1L) {
-                            serviceController.onAnnotation(time, text)
-                        }
-                    }
-                }
-//                else if(intent.action == STATUS && running){
-//                    sendBroadcast(Intent(RUNNING))
-//                }
-            }
-        }
-    }
-
-    inner class MeasurementBinder : Binder() {
-        fun getService(): MeasurementService {
-            return this@MeasurementService
-        }
-
-    }
-
-    override fun onBind(p0: Intent?): IBinder {
-        return MeasurementBinder()
-    }
-
-    interface OnMeasurementStateListener {
-        fun onServiceState(measurementStates: MeasurementStates)
-    }
-
-    // can pass information directly to the listener
-    // used mainly for the short measurement to pass countdown
-    var onMeasurementStateListener: OnMeasurementStateListener? = null
-
-    var running = false
-    var intent: Intent? = null
-    val startTime: Long = SystemClock.elapsedRealtime()
-
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val controller = ServiceController()
+    private var activeConfig: MeasurementConfig? = null
     private var wakeLock: PowerManager.WakeLock? = null
-    private var receiver: Boolean = false
-    private var shortJob: Job? = null
+    private var isStopping = false
+    private var batteryReceiverRegistered = false
+    private var startJob: Job? = null
+    private var durationJob: Job? = null
+    private var alarmJobs: List<Job> = emptyList()
 
-    // params
-    var paramType: Int = ENDLESS
-    var paramSensorId: IntArray? = null
-    private var paramInternalStorage = false
-    private var paramTimeIntervals: IntArray = intArrayOf(-1)
-    private var paramChecks: BooleanArray = booleanArrayOf(false, false, false, false, false)
+    private val lowBatteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_BATTERY_LOW) stopMeasurement()
+        }
+    }
 
-    // main controller for measurement
-    private val serviceController: ServiceController = ServiceController()
-
-    // wear Os references
-    private val wearOsHandler: WearOsHandler = WearOsHandler()
-    private var wearOsPresence: WearOsStates.PresenceResult? = null
-    private var wearOsJob: Job? = null
-
+    override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        running = true
-        intent?.let {
-            unwrapIntent(it)
-        }
+        when (intent?.action) {
+            ACTION_STOP -> stopMeasurement()
 
-        if (!paramInternalStorage) { // show notification at phone only
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(
-                    ONGOING_NOTIFICATION_ID, Notify.createNotification(
-                        applicationContext, getString(
-                            R.string.notification_title
-                        ), getString(R.string.notification_content)
-                    ),
-                    if (Build.VERSION.SDK_INT >= 34) FOREGROUND_SERVICE_TYPE_HEALTH else FOREGROUND_SERVICE_TYPE_LOCATION
-                )
+            ACTION_ANNOTATE -> controller.annotate(
+                intent.getLongExtra(ANNOTATION_TIME, System.currentTimeMillis()),
+                intent.getStringExtra(ANNOTATION_TEXT).orEmpty(),
+            )
 
-            } else {
-                startForeground(
-                    ONGOING_NOTIFICATION_ID,
-                    Notify.createNotification(
-                        applicationContext, getString(
-                            R.string.notification_title
-                        ), getString(R.string.notification_content)
-                    ),
-                )
+            else -> intent?.takeIf { activeConfig == null }?.let { startIntent ->
+                startMeasurement(startIntent).onFailure { stopMeasurement() }
             }
-
-            // search for Wear Os
-            wearOsJob = CoroutineScope(Dispatchers.Main).launch {
-                wearOsHandler.searchForWearOs(
-                    this@MeasurementService,
-                    this@MeasurementService,
-                    WearOsConstants.WEAR_APP_CAPABILITY
-                )
-            }
-
         }
 
-        handleAndroid()
-
-        serviceController.onInit(this, intent)
-
-        if (!serviceController.onStart(this)) {
-            cancelService()
-        }
-
-        when (paramType) {
-            SHORT -> createShortTimer()
-//            LONG -> createLongTimer()
-            ENDLESS -> START_REDELIVER_INTENT
-        }
         return START_NOT_STICKY
     }
 
-    /**
-     * checks wakeLock and registers receiver
-     *
-     */
-    private fun handleAndroid() {
-        wakeLockHandle()
-        createBroadcastReceiver()
+    private fun startMeasurement(intent: Intent): Result<Unit> = appResult(
+        AppError.Kind.MEASUREMENT,
+        "Start measurement service",
+    ) {
+        val config = MeasurementConfig.from(intent)
+        activeConfig = config
+        promoteToForeground(config)
+        publishRunningSession(config)
+        configureRuntimeResources(config)
+        scheduleMeasurementStart(config)
     }
 
-    /**
-     * picks necessary parameters from the intent
-     *
-     * @param intent - formated by companion methods below
-     */
-    private fun unwrapIntent(intent: Intent) {
-
-        this.intent = intent
-        intent.extras?.let {
-            paramSensorId = it.getIntArray(ANDROID_SENSORS)
-            paramType = it.getInt(TYPE, ENDLESS)
-            paramTimeIntervals = it.getIntArray(TIME_INTERVALS)!!
-            paramChecks = it.getBooleanArray(OTHER)!!
-            paramInternalStorage = it.getBoolean(INTERNAL_STORAGE)
-        }
-    }
-
-    /**
-     * registers receiver for the intent to stop service / write annotation
-     * also can registers intents for battery status and controls the battery %
-     */
-    @SuppressLint("UnspecifiedRegisterReceiverFlag")
-    private fun createBroadcastReceiver() {
-        val intentFilter = IntentFilter(STOP_SERVICE)
-        intentFilter.addAction(ANNOTATION)
-//        intentFilter.addAction(STATUS)
-
-        if (paramChecks[2]) {
-            intentFilter.addAction(Intent.ACTION_BATTERY_LOW)
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            registerReceiver(serviceBroadcastReceiver, intentFilter, RECEIVER_EXPORTED)
-        } else {
-            registerReceiver(serviceBroadcastReceiver, intentFilter)
-        }
-
-        receiver = true
-    }
-
-    /**
-     * uses own kotlin flow to countdown SHORT measurement with delay of 1000 ms
-     *
-     */
-    private fun createShortTimer() {
-        shortJob = CoroutineScope(Dispatchers.Default).launch {
-            serviceController.shortTimer().onEach { state ->
-                withContext(Dispatchers.Main) {
-
-                    if (state is MeasurementStates.OnShortEnd) { // on the end of the countdown
-                        onMeasurementStateListener?.onServiceState(
-                            MeasurementStates.OnEndMeasurement(
-                                paramType,
-                                paramChecks[4] // repetition
-                            )
-                        )
-                        onMeasurementStateListener?.onServiceState(MeasurementStates.StateNothing)
-                        sendOnFinishNotification()
-                        serviceController.onStop(this@MeasurementService)
-                        cancelService()
-                    } else {
-                        // passing seconds left
-                        onMeasurementStateListener?.onServiceState(state)
-                    }
-
-                }
-            }.launchIn(this)
-        }
-
-    }
-
-//    private fun createLongTimer() {
-//        serviceController.longTimer(this)
-//    }
-
-    /**
-     * acquires wakelock with time limit for LONG/SHORT measurement
-     *
-     */
-    @SuppressLint("WakelockTimeout")
-    private fun wakeLockHandle() {
-        if (paramChecks[3]) { // wakelock flag
-            wakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
-                newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SensorBox::Measuring").apply {
-                    when (paramType) {
-                        SHORT -> {
-                            acquire(paramTimeIntervals[1] * 1000L)
-                        }
-//                        LONG -> {
-//                            acquire(((paramTimeIntervals[0] * 3600 + paramTimeIntervals[1] * 60) * 1000).toLong())
-//                        }
-                        else -> {
-                            acquire()
-                        }
-                    }
+    private fun scheduleMeasurementStart(config: MeasurementConfig) {
+        startJob = serviceScope.launch {
+            delay((config.startAtEpochMillis - System.currentTimeMillis()).coerceAtLeast(0L))
+            if (controller.start(this@MeasurementService, config).isFailure) {
+                stopMeasurement()
+                return@launch
+            }
+            scheduleAlarms(config)
+            if (config.durationMillis > 0L) {
+                durationJob = serviceScope.launch {
+                    delay(config.durationMillis)
+                    stopMeasurement()
                 }
             }
         }
     }
 
-    /**
-     * finishing notification after stopping of the service
-     *
-     */
-    private fun sendOnFinishNotification() {
-        Notify.updateNotification(
-            this, FINISH_NOTIFICATION,
-            Notify.endingNotification(
-                this,
-                getString(R.string.notification_finish_title),
-                getString(R.string.notification_finish_content)
-            )
+    private fun scheduleAlarms(config: MeasurementConfig) {
+        alarmJobs = config.alarmOffsetsSeconds.distinct().sorted().map { seconds ->
+            serviceScope.launch {
+                delay(seconds * 1_000L)
+                controller.playAlarm()
+            }
+        }
+    }
+
+    private fun promoteToForeground(config: MeasurementConfig) {
+        val notification = Notify.createRecordingNotification(this)
+        if (Build.VERSION.SDK_INT >= 34) {
+            startForeground(NOTIFICATION_ID, notification, foregroundTypes(config))
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun foregroundTypes(config: MeasurementConfig): Int = if (config.includesGps) {
+        FOREGROUND_SERVICE_TYPE_HEALTH or FOREGROUND_SERVICE_TYPE_LOCATION
+    } else {
+        FOREGROUND_SERVICE_TYPE_HEALTH
+    }
+
+    private fun publishRunningSession(config: MeasurementConfig) {
+        val delayMillis = (config.startAtEpochMillis - System.currentTimeMillis()).coerceAtLeast(0L)
+        sessionStore.markRunning(
+            MeasurementSessionState.Running(
+                folderName = config.folderName,
+                startedAtElapsedRealtime = SystemClock.elapsedRealtime() + delayMillis,
+                sensorIds = config.sensorIds.toList(),
+                includesGps = config.includesGps,
+            ),
         )
     }
 
-    /**
-     * method stop measurement from the service
-     *
-     */
-    private fun cancelService() {
-        if (running) {
-            running = false
+    private fun configureRuntimeResources(config: MeasurementConfig) {
+        if (config.useWakeLock) acquireWakeLock()
+        if (config.stopOnLowBattery) registerLowBatteryReceiver()
+    }
 
-            onMeasurementStateListener?.onServiceState( // ending to activity
-                MeasurementStates.OnEndMeasurement(
-                    paramType,
-                    paramChecks[4]
-                )
-            )
+    private fun acquireWakeLock() {
+        val powerManager = getSystemService(PowerManager::class.java)
+        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG).apply {
+            acquire()
+        }
+    }
 
-            onMeasurementStateListener?.onServiceState(MeasurementStates.StateNothing)
-
-            shortJob?.cancel()
-
-            val savingJob = CoroutineScope(Dispatchers.Main).launch {
-                serviceController.onStop(this@MeasurementService)
-            } // stops measurement
-            savingJob.invokeOnCompletion {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                onMeasurementStateListener = null
-                wearOsJob?.cancel() // cancels Wear Os
-                wearOsHandler.onDestroy()
-                stopSelf()
-            }
-
+    private fun registerLowBatteryReceiver() {
+        val filter = IntentFilter(Intent.ACTION_BATTERY_LOW)
+        if (Build.VERSION.SDK_INT >= 33) {
+            registerReceiver(lowBatteryReceiver, filter, RECEIVER_NOT_EXPORTED)
         } else {
-            wearOsJob?.cancel() // cancels Wear Os
-            wearOsHandler.onDestroy()
+            registerReceiver(lowBatteryReceiver, filter)
+        }
+        batteryReceiverRegistered = true
+    }
+
+    private fun stopMeasurement() {
+        if (isStopping) return
+        isStopping = true
+        sessionStore.markStopping()
+        serviceScope.launch {
+            val failures = mutableListOf<Throwable>()
+            controller.stop(this@MeasurementService).exceptionOrNull()?.let(failures::add)
+            stopRemoteMeasurement().exceptionOrNull()?.let(failures::add)
+            finishService().exceptionOrNull()?.let(failures::add)
+            failures.firstOrNull()?.let { first ->
+                failures.drop(1).forEach(first::addSuppressed)
+                AppError.from(AppError.Kind.MEASUREMENT, "Stop measurement service", first)
+            }
+        }
+    }
+
+    private suspend fun stopRemoteMeasurement(): Result<Unit> {
+        val config = activeConfig ?: return Result.success(Unit)
+        if (config.useInternalStorage || !config.controlsWearMeasurement) return Result.success(Unit)
+        return WearCommandCodec.encode(WearCommand.StopMeasurement).suspendFlatMap { payload ->
+            sendWearMessage(WEAR_APP_CAPABILITY, WEAR_MESSAGE_PATH, payload)
+        }
+    }
+
+    private fun finishService(): Result<Unit> {
+        val results = mutableListOf<Result<*>>()
+        results += releaseRuntimeResources()
+        activeConfig = null
+        isStopping = false
+        results += appResult(AppError.Kind.MEASUREMENT, "Publish idle measurement state") {
+            sessionStore.markIdle()
+        }
+        results += appResult(AppError.Kind.MEASUREMENT, "Remove measurement notification") {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }
+        results += appResult(AppError.Kind.MEASUREMENT, "Stop measurement service instance") {
             stopSelf()
         }
+        return results.combineAppResults(AppError.Kind.MEASUREMENT, "Finish measurement service")
+    }
 
+    private fun releaseRuntimeResources(): Result<Unit> {
+        val results = mutableListOf<Result<*>>()
+        startJob?.cancel()
+        startJob = null
+        durationJob?.cancel()
+        durationJob = null
+        alarmJobs.forEach(Job::cancel)
+        alarmJobs = emptyList()
+        results += appResult(AppError.Kind.MEASUREMENT, "Release measurement wake lock") {
+            wakeLock?.takeIf(PowerManager.WakeLock::isHeld)?.release()
+        }
+        wakeLock = null
+        results += appResult(AppError.Kind.MEASUREMENT, "Unregister low battery receiver") {
+            if (batteryReceiverRegistered) unregisterReceiver(lowBatteryReceiver)
+        }
+        batteryReceiverRegistered = false
+        return results.combineAppResults(AppError.Kind.MEASUREMENT, "Release measurement resources")
     }
 
     override fun onDestroy() {
+        if (activeConfig != null && !isStopping) {
+            AppError(AppError.Kind.MEASUREMENT, "Measurement service destroyed before cleanup")
+        }
+        releaseRuntimeResources()
+        appResult(AppError.Kind.MEASUREMENT, "Publish destroyed measurement state") { sessionStore.markIdle() }
+        serviceScope.cancel()
         super.onDestroy()
-
-        stopForeground(STOP_FOREGROUND_REMOVE)
-
-        if (wakeLock != null) {
-            if (wakeLock!!.isHeld) {
-                wakeLock!!.release()
-            }
-        }
-
-        wearOsPresence?.let {
-            if (!paramInternalStorage && it.present) { // If there is internal storage - Wear Os usage
-                removeWearOs()
-            }
-        }
-
-
-
-        if (receiver) {
-            unregisterReceiver(serviceBroadcastReceiver)
-            receiver = false
-        }
-        running = false
     }
-
-    /**
-     * callback for Wear Os presence
-     *
-     * @param wearOsStates - PresenceResult for Wear Os
-     */
-    override suspend fun onWearOsStates(wearOsStates: WearOsStates) {
-        if (wearOsStates is WearOsStates.PresenceResult) {
-            wearOsPresence = wearOsStates
-        }
-    }
-
-    /**
-     * sends message to Wear Os to stop all the operations
-     * laced mainly here, so the service can be standalone and the Wear Os measurement is stopped
-     * by actual service in phone
-     */
-    private fun removeWearOs() {
-        wearOsHandler.sendMsg(
-            this,
-            WearOsConstants.WEAR_MESSAGE_PATH,
-            WearOsConstants.WEAR_KILL_APP,
-            silent = true
-        )
-        wearOsHandler.onDestroy()
-    }
-
 
     companion object {
-
-
-        // notifications
-        const val FINISH_NOTIFICATION = 465
-        private const val ONGOING_NOTIFICATION_ID = 729
-
-        // parameters
         const val FOLDER_NAME = "FOLDER_NAME"
-        const val CUSTOM_NAME = "CUSTOM_NAME"
         const val INTERNAL_STORAGE = "INTERNAL_STORAGE"
-        const val OTHER = "OTHER"
-        private const val ALARMS = "ALARMS"
-        internal const val NOTES = "NOTES"
-        const val TIME_INTERVALS = "TIME_INTERVALS"
         const val ANDROID_SENSORS = "ANDROID_SENSORS"
         const val ANDROID_SENSORS_SPEED = "ANDROID_SENSORS_SPEED"
         const val GPS = "GPS_MEASURE"
-        const val TYPE = "TYPE"
-        const val WEAR_SENSORS = "WEAR_SENSORS"
-
-        // types
-        const val SHORT = 0
-        const val ENDLESS = 1
-//        const val LONG = 2
-
-        const val SHORT_STRING = "SHORT"
-        const val ENDLESS_STRING = "ENDLESS"
-        const val LONG_STRING = "LONG"
-
-
-        // intents
-        const val USER = "USER"
-        const val STOP_ACTIVITY = "STOP_ACTIVITY"
-        const val STOP_SERVICE = "STOP_SERVICE"
-        const val ANNOTATION = "ANNOTATION"
-
-        //        const val STATUS = "STATUS"
-        const val RUNNING = "RUNNING"
+        const val STOP_ON_LOW_BATTERY = "STOP_ON_LOW_BATTERY"
+        const val USE_WAKE_LOCK = "USE_WAKE_LOCK"
+        const val GPS_INTERVAL_SECONDS = "GPS_INTERVAL_SECONDS"
+        const val GPS_DISTANCE_METERS = "GPS_DISTANCE_METERS"
+        const val MEASUREMENT_TYPE = "MEASUREMENT_TYPE"
+        const val START_AT_EPOCH_MILLIS = "START_AT_EPOCH_MILLIS"
+        const val DURATION_MILLIS = "DURATION_MILLIS"
+        const val NOTES = "NOTES"
+        const val ALARM_OFFSETS_SECONDS = "ALARM_OFFSETS_SECONDS"
+        const val ACTIVITY_RECOGNITION = "ACTIVITY_RECOGNITION"
+        const val ACTIVITY_RECOGNITION_PERIOD_SECONDS = "ACTIVITY_RECOGNITION_PERIOD_SECONDS"
+        const val SIGNIFICANT_MOTION = "SIGNIFICANT_MOTION"
+        const val CONTROLS_WEAR_MEASUREMENT = "CONTROLS_WEAR_MEASUREMENT"
+        const val ACTION_ANNOTATE = "com.motionapps.sensorbox.action.ANNOTATE_MEASUREMENT"
         const val ANNOTATION_TIME = "ANNOTATION_TIME"
         const val ANNOTATION_TEXT = "ANNOTATION_TEXT"
+        const val ACTION_STOP = "com.motionapps.sensorbox.action.STOP_MEASUREMENT"
 
-        /**
-         * used for basic measurement in HomeFragment
-         *
-         * @param intent - intent for MeasurementService
-         * @param internalStorage - to use in Wear Os - true
-         * @param sensorsToMeasure // default
-         * @param gpsToMeasure - true to use GPS
-         * @param nameOfFolder - string with formatted name ENDLESS_10_9_2020_20_50_30
-         * @param wearSensors - intArray of sensor Ids for Wear Os - can be null
-         * @return filled intent with extras based on string on top of the companion object
-         */
-        fun addExtraToIntentBasic(
-            intent: Intent,
-            internalStorage: Boolean,
-            sensorsToMeasure: IntArray,
-            gpsToMeasure: Boolean,
-            nameOfFolder: String,
-            wearSensors: IntArray?
-        ): Intent {
-            return intent.apply {
-                putExtra(FOLDER_NAME, nameOfFolder)
-                putExtra(INTERNAL_STORAGE, internalStorage)
-                putExtra(ANDROID_SENSORS, sensorsToMeasure)
-                putExtra(WEAR_SENSORS, wearSensors)
-                putExtra(ANDROID_SENSORS_SPEED, SensorManager.SENSOR_DELAY_FASTEST) // default
-                putExtra(GPS, gpsToMeasure)
-                putExtra(TYPE, ENDLESS)
-                putExtra(TIME_INTERVALS, intArrayOf(-1)) // not used
-                putExtra(NOTES, arrayListOf("")) // not used
-                putExtra(ALARMS, intArrayOf(-1)) // not used
-                putExtra(OTHER, booleanArrayOf(false, false, false, false, false)) // default
-            }
-
-        }
-
-        /**
-         * used in Advanced Measurement to pack all the parameters
-         *
-         * @param intent - intent to MeasurementService
-         * @param folder - whole folder name
-         * @param customName - pure custom string with name for folder
-         * @param internalStorage - to use in Wear Os, this should be true
-         * @param sensorsToMeasure - intArray with sensors Ids to measure
-         * @param speedSensor - SensorManager.SENSOR_DELAY_FAST, ...
-         * @param gpsToMeasure - true to measure GPS
-         * @param typeMeasurement - SHORT / ENDLESS / LONG
-         * @param timeIntervals - SHORT [time to start in seconds, time to measure in seconds], LONG [hours, minutes]
-         * @param notes - arrayList of strings to store
-         * @param alarms - arrayList of ints with seconds in which to launch alarms
-         * @param checkCheckBoxes - another parameters - [extra_checkbox_activity, significant_motion, battery, cpu, repeat]
-         * @param wearSensors - intArray of ids for sensors in Wear Os
-         * @return - filled intent
-         */
-        fun addExtraToIntentAdvanced(
-            intent: Intent,
-            folder: String,
-            customName: String,
-            internalStorage: Boolean,
-            sensorsToMeasure: IntArray,
-            speedSensor: Int,
-            gpsToMeasure: Boolean,
-            typeMeasurement: Int,
-            timeIntervals: Array<Int>,
-            notes: ArrayList<String>,
-            alarms: ArrayList<Int>,
-            checkCheckBoxes: Array<Boolean>,
-            wearSensors: IntArray?
-        ): Intent {
-
-            return intent.apply {
-                putExtra(FOLDER_NAME, folder)
-                putExtra(CUSTOM_NAME, customName)
-                putExtra(INTERNAL_STORAGE, internalStorage)
-                putExtra(ANDROID_SENSORS, sensorsToMeasure)
-                putExtra(ANDROID_SENSORS_SPEED, speedSensor)
-                putExtra(GPS, gpsToMeasure)
-                putExtra(TYPE, typeMeasurement)
-                putExtra(TIME_INTERVALS, timeIntervals.toIntArray())
-                putExtra(NOTES, notes)
-                putExtra(ALARMS, alarms.toIntArray())
-                putExtra(OTHER, checkCheckBoxes.toBooleanArray())
-                wearSensors?.let {
-                    putExtra(WEAR_SENSORS, wearSensors)
-                }
-            }
-        }
-
-        /**
-         * Wear Os intent - customized for specific needs - creates ENDLESS measurement
-         *
-         * @param context
-         * @param path - to store data
-         * @param sensors - intArray of sensors to use
-         * @param sensorSpeed - SensorManager.SENSOR_DELAY_FAST, ...
-         * @param battery - stop on low battery - true
-         * @param wakeLock - lock the cpu - true
-         * @return filled Intent with  params
-         */
-        fun getIntentWearOs(
-            context: Context,
-            path: String,
-            sensors: IntArray,
-            sensorSpeed: Int,
-            gps: Boolean,
-            battery: Boolean,
-            wakeLock: Boolean
-        ): Intent {
-            val intent = Intent(context, MeasurementService::class.java)
-
-            return addExtraToIntentAdvanced(
-                intent,
-                path,
-                "",
-                true,
-                sensors,
-                sensorSpeed,
-                gps,
-                ENDLESS,
-                arrayOf(-1),
-                arrayListOf(""),
-                arrayListOf(-1),
-                arrayOf(
-                    false,
-                    false,
-                    battery,
-                    wakeLock,
-                    false
-                ),
-                null
-            )
-        }
-
-        /**
-         * generates folder name with current timestamp
-         *
-         * @param type - SHORT, ENDLESS, LONG
-         * @param customName - can be empty, if it is not, then the name replaces the type in name
-         * @return - folder name
-         */
-        fun generateFolderName(type: Int, customName: String = ""): String {
-            val date = StorageHandler.getDate(System.currentTimeMillis(), "dd_MM_yyyy_HH_mm_ss")
-            return if (customName != "") {
-                "%s_%s".format(customName, date)
-            } else {
-                val measurement = when (type) {
-                    SHORT -> SHORT_STRING
-//                    LONG -> LONG_STRING
-                    else -> ENDLESS_STRING
-                }
-                "%s_%s".format(measurement, date)
-            }
-
-        }
-
-        // settings keys
-        const val ACTIVITY_RECOGNITION_PERIOD = "activity_recognition_period"
-        const val GPS_DISTANCE = "gps_distance"
-        const val GPS_TIME = "gps_time"
-
-        val PREFS = arrayOf(
-            ACTIVITY_RECOGNITION_PERIOD,
-            GPS_DISTANCE,
-            GPS_TIME
-        )
-
+        private const val NOTIFICATION_ID = 729
+        private const val WAKE_LOCK_TAG = "SensorBox::Measurement"
     }
-
-
 }

--- a/sensorservices/src/main/java/com/motionapps/sensorservices/services/MeasurementStates.kt
+++ b/sensorservices/src/main/java/com/motionapps/sensorservices/services/MeasurementStates.kt
@@ -1,9 +1,0 @@
-package com.motionapps.sensorservices.services
-
-sealed class MeasurementStates {
-
-    class OnTick(val tick: Int): MeasurementStates()
-    object OnShortEnd: MeasurementStates()
-    object StateNothing : MeasurementStates()
-    class OnEndMeasurement(val type: Int, val repeat: Boolean): MeasurementStates()
-}

--- a/sensorservices/src/main/java/com/motionapps/sensorservices/services/Notify.kt
+++ b/sensorservices/src/main/java/com/motionapps/sensorservices/services/Notify.kt
@@ -1,117 +1,46 @@
 package com.motionapps.sensorservices.services
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
-import androidx.core.content.ContextCompat
 import com.motionapps.sensorservices.R
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.InternalCoroutinesApi
 
-@ExperimentalCoroutinesApi
-@InternalCoroutinesApi
 object Notify {
-    private const val CHANNEL_ID = "SensorBoxId"
-    private const val CHANNEL_NAME = "SensorBoxChannel"
-
-    /**
-     * basic notification for foreground of MeasurementService
-     *
-     * @param context
-     * @param title - title of the notification
-     * @param content - subtext of notification
-     * @return built notification
-     */
-    @SuppressLint("UnspecifiedImmutableFlag")
-    fun createNotification(context: Context, title: String?, content: String?): Notification {
-
+    fun createRecordingNotification(context: Context): Notification {
         createChannel(context)
-        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-        builder.setContentTitle(title)
-        builder.setAutoCancel(false)
-        builder.setStyle(NotificationCompat.BigTextStyle().bigText(content))
-
-        builder.setSmallIcon(R.drawable.ic_graph)
-        builder.color = ContextCompat.getColor(context, R.color.colorBlack)
-
-        builder.priority = NotificationManager.IMPORTANCE_DEFAULT
-        builder.setCategory(Notification.CATEGORY_SERVICE)
-
-        val stopIntent = Intent(MeasurementService.STOP_SERVICE)
-        val stopPendingIntent = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
-            PendingIntent.getBroadcast(context, 20, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-        }else{
-            PendingIntent.getBroadcast(context, 20, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT)
-        }
-
-        builder.addAction(R.drawable.ic_stop, context.getString(R.string.text_stop), stopPendingIntent)
-
-        return builder.build()
+        val stopIntent = Intent(context, MeasurementService::class.java)
+            .setAction(MeasurementService.ACTION_STOP)
+        val stopAction = PendingIntent.getService(
+            context,
+            STOP_REQUEST_CODE,
+            stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(context.getString(R.string.notification_title))
+            .setContentText(context.getString(R.string.notification_content))
+            .setSmallIcon(R.drawable.ic_graph)
+            .setOngoing(true)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .addAction(R.drawable.ic_stop, context.getString(R.string.text_stop), stopAction)
+            .build()
     }
-
-    /**
-     * notification at the end of the measurement
-     *
-     * @param context
-     * @param title - title of the notification
-     * @param content - subtext of notification
-     * @return built notification
-     */
-    fun endingNotification(context: Context, title: String?, content: String?): Notification {
-
-        createChannel(context)
-        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
-        builder.setContentTitle(title)
-        builder.setAutoCancel(false)
-        builder.setStyle(NotificationCompat.BigTextStyle().bigText(content))
-        builder.setSound(Uri.parse("android.resource://" + context.packageName + "/" + R.raw.end))
-
-        builder.setSmallIcon(R.drawable.ic_graph)
-        builder.color = ContextCompat.getColor(context, R.color.colorBlack)
-
-        builder.priority = NotificationManager.IMPORTANCE_DEFAULT
-        builder.setCategory(Notification.CATEGORY_SERVICE)
-
-        return builder.build()
-    }
-
-
-    /**
-     * replaces notification
-     *
-     * @param context
-     * @param id - id of the notification
-     * @param notification - notification to to be placed
-     */
-    fun updateNotification(context: Context, id: Int, notification: Notification) {
-        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(id, notification)
-    }
-
-    /**
-     * cancels notification by id
-     *
-     * @param context
-     * @param id - of notification to cancel
-     */
-    fun cancelNotification(context: Context, id: Int) {
-        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.cancel(id)
-    }
-
 
     private fun createChannel(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val notificationChannel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
-            val notificationManager = context.getSystemService(NotificationManager::class.java)
-            notificationManager?.createNotificationChannel(notificationChannel)
-        }
+        if (Build.VERSION.SDK_INT < 26) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW,
+        )
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
+
+    private const val CHANNEL_ID = "measurement"
+    private const val STOP_REQUEST_CODE = 20
 }


### PR DESCRIPTION
Architecture stack 6 of 39.

Base: `architecture/05-sensorservice-measurements`
Head: `architecture/06-sensorservice-runtime`
Changed lines in this layer: 1210.

This layer contains the domain-focused change named in the title. Review the numbered stack in order. This PR targets the branch immediately before it, so GitHub shows only this layer.

Stack navigation: previous #58; next #62.