### PR TITLE
[16/39] feat(wear): add Compose wearable features

### DIFF
--- a/wear/src/main/java/com/motionapps/sensorbox/domain/measurement/WearMeasurementControlUseCase.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/measurement/WearMeasurementControlUseCase.kt
@@ -1,0 +1,64 @@
+package com.motionapps.sensorbox.domain.measurement
+
+import android.content.Context
+import android.content.Intent
+import android.hardware.SensorManager
+import androidx.core.content.ContextCompat
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+import com.motionapps.sensorbox.core.preferences.AppPreferences
+import com.motionapps.sensorservices.intent.MeasurementIntentFactory
+import com.motionapps.sensorservices.intent.MeasurementLaunchRequest
+import com.motionapps.sensorservices.services.MeasurementService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class WearMeasurementControlUseCase @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val intentFactory: MeasurementIntentFactory,
+) {
+    fun start(
+        sensorIds: Set<Int>,
+        includesGps: Boolean,
+        preferences: AppPreferences,
+        folderName: String = intentFactory.newFolderName(),
+        startAtEpochMillis: Long = System.currentTimeMillis(),
+        durationMillis: Long = 0L,
+        measurementType: String = "ENDLESS",
+    ): Result<Unit> = appResult(AppError.Kind.MEASUREMENT, "Request Wear measurement start") {
+        val request = MeasurementLaunchRequest(
+            folderName = folderName,
+            useInternalStorage = true,
+            sensorIds = sensorIds,
+            sensorSamplingPeriod = samplingPeriod(preferences.sensorSamplingPeriod),
+            includesGps = includesGps,
+            stopOnLowBattery = preferences.restrictMeasurementOnLowBattery,
+            useWakeLock = preferences.useWakeLock,
+            gpsIntervalSeconds = preferences.gpsIntervalSeconds,
+            gpsMinDistanceMeters = preferences.gpsMinDistanceMeters,
+            measurementType = measurementType,
+            startAtEpochMillis = startAtEpochMillis,
+            durationMillis = durationMillis,
+        )
+        ContextCompat.startForegroundService(context, intentFactory.create(request))
+    }
+
+    fun stop(): Result<Unit> = appResult(AppError.Kind.MEASUREMENT, "Request Wear measurement stop") {
+        val intent = Intent(context, MeasurementService::class.java)
+            .setAction(MeasurementService.ACTION_STOP)
+        context.startService(intent)
+    }
+
+    private fun samplingPeriod(index: Int): Int = SENSOR_PERIODS.getOrElse(index) {
+        SensorManager.SENSOR_DELAY_FASTEST
+    }
+
+    private companion object {
+        val SENSOR_PERIODS = intArrayOf(
+            SensorManager.SENSOR_DELAY_FASTEST,
+            SensorManager.SENSOR_DELAY_GAME,
+            SensorManager.SENSOR_DELAY_UI,
+            SensorManager.SENSOR_DELAY_NORMAL,
+        )
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/domain/measurement/WearMeasurementPermissionUseCase.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/measurement/WearMeasurementPermissionUseCase.kt
@@ -1,0 +1,30 @@
+package com.motionapps.sensorbox.domain.measurement
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.health.connect.HealthPermissions
+import android.os.Build
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class WearMeasurementPermissionUseCase @Inject constructor(@ApplicationContext private val context: Context) {
+    operator fun invoke(includesGps: Boolean, includesHeartRate: Boolean): Set<String> = buildSet {
+        if (Build.VERSION.SDK_INT >= 33) add(Manifest.permission.POST_NOTIFICATIONS)
+        if (includesGps) add(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (includesHeartRate) addHeartRatePermissions()
+    }.filterNot(::isGranted).toSet()
+
+    private fun MutableSet<String>.addHeartRatePermissions() {
+        if (Build.VERSION.SDK_INT >= 36) {
+            add(HealthPermissions.READ_HEART_RATE)
+            add(HealthPermissions.READ_HEALTH_DATA_IN_BACKGROUND)
+        } else {
+            add(Manifest.permission.BODY_SENSORS)
+        }
+    }
+
+    private fun isGranted(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/GetWearSensorsUseCase.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/GetWearSensorsUseCase.kt
@@ -1,0 +1,44 @@
+package com.motionapps.sensorbox.domain.sensors
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class GetWearSensorsUseCase @Inject constructor(@ApplicationContext context: Context) {
+    private val sensorManager = context.getSystemService(SensorManager::class.java)
+
+    operator fun invoke(): List<WearSensorDescriptor> = sensorManager
+        .getSensorList(Sensor.TYPE_ALL)
+        .filter { it.type in SUPPORTED_SENSOR_TYPES }
+        .distinctBy(Sensor::getType)
+        .map { sensor -> sensor.toDescriptor() }
+        .sortedBy(WearSensorDescriptor::name)
+
+    private fun Sensor.toDescriptor() = WearSensorDescriptor(
+        type = type,
+        name = name,
+        vendor = vendor,
+        isHeartRate = type == Sensor.TYPE_HEART_RATE,
+    )
+
+    private companion object {
+        val SUPPORTED_SENSOR_TYPES = setOf(
+            Sensor.TYPE_ACCELEROMETER,
+            Sensor.TYPE_AMBIENT_TEMPERATURE,
+            Sensor.TYPE_GRAVITY,
+            Sensor.TYPE_GYROSCOPE,
+            Sensor.TYPE_HEART_RATE,
+            Sensor.TYPE_LIGHT,
+            Sensor.TYPE_LINEAR_ACCELERATION,
+            Sensor.TYPE_MAGNETIC_FIELD,
+            Sensor.TYPE_PRESSURE,
+            Sensor.TYPE_PROXIMITY,
+            Sensor.TYPE_RELATIVE_HUMIDITY,
+            Sensor.TYPE_ROTATION_VECTOR,
+            Sensor.TYPE_STEP_COUNTER,
+            Sensor.TYPE_STEP_DETECTOR,
+        )
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/ObserveSensorValuesUseCase.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/ObserveSensorValuesUseCase.kt
@@ -1,0 +1,41 @@
+package com.motionapps.sensorbox.domain.sensors
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import javax.inject.Inject
+
+class ObserveSensorValuesUseCase @Inject constructor(@ApplicationContext context: Context) {
+    private val sensorManager = context.getSystemService(SensorManager::class.java)
+
+    operator fun invoke(sensorType: Int): Flow<Float> = callbackFlow {
+        val sensor = sensorManager.getDefaultSensor(sensorType)
+        if (sensor == null) {
+            close(IllegalArgumentException("Sensor type $sensorType is unavailable"))
+            return@callbackFlow
+        }
+        val listener = sensorListener { value -> trySend(value) }
+        val registered = sensorManager.registerListener(
+            listener,
+            sensor,
+            SensorManager.SENSOR_DELAY_UI,
+        )
+        if (!registered) close(IllegalStateException("Unable to observe ${sensor.name}"))
+        awaitClose { sensorManager.unregisterListener(listener) }
+    }.conflate()
+
+    private fun sensorListener(onValue: (Float) -> Unit) = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            event.values.firstOrNull()?.let(onValue)
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/WearSensorDescriptor.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/sensors/WearSensorDescriptor.kt
@@ -1,0 +1,3 @@
+package com.motionapps.sensorbox.domain.sensors
+
+data class WearSensorDescriptor(val type: Int, val name: String, val vendor: String, val isHeartRate: Boolean)

--- a/wear/src/main/java/com/motionapps/sensorbox/domain/sync/SyncWearMeasurementsUseCase.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/domain/sync/SyncWearMeasurementsUseCase.kt
@@ -1,0 +1,61 @@
+package com.motionapps.sensorbox.domain.sync
+
+import android.content.Context
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.error.appResult
+import com.motionapps.sensorbox.core.error.suspendAppResult
+import com.motionapps.sensorbox.core.error.suspendFlatMap
+import com.motionapps.sensorbox.core.error.withAppError
+import com.motionapps.wearoslib.WearOsConstants.PHONE_APP_CAPABILITY
+import com.motionapps.wearoslib.connectivity.WearConnectionRepository
+import com.motionapps.wearoslib.files.WearFileMetadata
+import com.motionapps.wearoslib.files.WearFileTransferClient
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+class SyncWearMeasurementsUseCase @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val connectionRepository: WearConnectionRepository,
+    private val transferClient: WearFileTransferClient,
+) {
+    suspend operator fun invoke(): Result<Int> = suspendAppResult(AppError.Kind.CONNECTIVITY, "Find phone") {
+        connectionRepository.findNode(PHONE_APP_CAPABILITY)
+    }.suspendFlatMap { node ->
+        if (node == null) {
+            return@suspendFlatMap Result.failure(AppError(AppError.Kind.CONNECTIVITY, "Find connected phone"))
+        }
+        appResult(AppError.Kind.STORAGE, "List Wear measurements", ::measurementFiles).suspendFlatMap { files ->
+            var transferResult: Result<Unit> = Result.success(Unit)
+            for (file in files) {
+                if (transferResult.isFailure) break
+                transferResult = sendFile(node.id, file)
+            }
+            transferResult.map { files.size }
+        }
+    }.withAppError(AppError.Kind.CONNECTIVITY, "Sync Wear measurements")
+
+    private suspend fun sendFile(nodeId: String, file: File): Result<Unit> {
+        val measurementName = file.parentFile?.name
+            ?: return Result.failure(AppError(AppError.Kind.STORAGE, "Read Wear measurement folder"))
+        return transferClient.send(
+            nodeId = nodeId,
+            metadata = WearFileMetadata(measurementName, file.name),
+            input = file::inputStream,
+        )
+    }
+
+    private fun measurementFiles(): List<File> {
+        val root = File(context.filesDir, APP_DIRECTORY)
+        return root.listFiles().orEmpty()
+            .filter(File::isDirectory)
+            .flatMap { folder -> folder.listFiles().orEmpty().asIterable() }
+            .filter { file -> file.isFile && file.extension.lowercase() in ALLOWED_EXTENSIONS }
+            .sortedBy(File::getAbsolutePath)
+    }
+
+    private companion object {
+        const val APP_DIRECTORY = "SensorBox"
+        val ALLOWED_EXTENSIONS = setOf("csv", "json", "txt")
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardContract.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardContract.kt
@@ -1,0 +1,83 @@
+package com.motionapps.sensorbox.presentation.dashboard
+
+import com.motionapps.sensorbox.core.preferences.AppPreferences
+import com.motionapps.sensorbox.domain.sensors.WearSensorDescriptor
+import com.motionapps.sensorbox.presentation.menu.WearMenuDestination
+
+enum class WearRoute { MENU, RECORD, LIVE, SETTINGS, ACTIVE }
+
+data class WearDashboardState(
+    val route: WearRoute = WearRoute.MENU,
+    val sensors: List<WearSensorDescriptor> = emptyList(),
+    val selectedSensorIds: Set<Int> = emptySet(),
+    val includesGps: Boolean = false,
+    val liveSensorType: Int? = null,
+    val latestValue: Float? = null,
+    val preferences: AppPreferences = AppPreferences(),
+    val isSyncing: Boolean = false,
+    val message: WearDashboardMessage? = null,
+)
+
+sealed interface WearDashboardMessage {
+    data object PickSource : WearDashboardMessage
+    data object PermissionRequired : WearDashboardMessage
+    data object SensorUnavailable : WearDashboardMessage
+    data object Syncing : WearDashboardMessage
+    data object SyncFailed : WearDashboardMessage
+    data class FilesSent(val count: Int) : WearDashboardMessage
+}
+
+sealed interface WearDashboardIntent {
+    data class Open(val destination: WearMenuDestination) : WearDashboardIntent
+    data object Back : WearDashboardIntent
+    data class ToggleSensor(val sensorType: Int) : WearDashboardIntent
+    data object ToggleGps : WearDashboardIntent
+    data object StartMeasurement : WearDashboardIntent
+    data class PermissionsResolved(val granted: Boolean) : WearDashboardIntent
+    data object StopMeasurement : WearDashboardIntent
+    data class ObserveSensor(val sensorType: Int) : WearDashboardIntent
+    data class SetSamplingPeriod(val index: Int) : WearDashboardIntent
+    data object ToggleBatteryRestriction : WearDashboardIntent
+    data object ToggleWakeLock : WearDashboardIntent
+    data object ToggleDisplay : WearDashboardIntent
+    data object SyncMeasurements : WearDashboardIntent
+}
+
+sealed interface WearDashboardEffect {
+    data class RequestPermissions(val permissions: Set<String>) : WearDashboardEffect
+    data object OpenPhone : WearDashboardEffect
+    data class OpenUrl(val destination: WearMenuDestination) : WearDashboardEffect
+}
+
+object WearDashboardReducer {
+    fun reduce(state: WearDashboardState, intent: WearDashboardIntent): WearDashboardState = when (intent) {
+        is WearDashboardIntent.Open -> state.copy(route = intent.destination.toRoute(), message = null)
+        WearDashboardIntent.Back -> state.copy(route = WearRoute.MENU, message = null)
+        is WearDashboardIntent.ToggleSensor -> state.toggleSensor(intent.sensorType)
+        WearDashboardIntent.ToggleGps -> state.copy(includesGps = !state.includesGps)
+        is WearDashboardIntent.ObserveSensor -> state.selectLiveSensor(intent.sensorType)
+        else -> state
+    }
+
+    private fun WearDashboardState.selectLiveSensor(sensorType: Int) = copy(
+        route = WearRoute.LIVE,
+        liveSensorType = sensorType,
+        latestValue = null,
+    )
+
+    private fun WearDashboardState.toggleSensor(sensorType: Int): WearDashboardState {
+        val nextIds = if (sensorType in selectedSensorIds) {
+            selectedSensorIds - sensorType
+        } else {
+            selectedSensorIds + sensorType
+        }
+        return copy(selectedSensorIds = nextIds, message = null)
+    }
+
+    private fun WearMenuDestination.toRoute(): WearRoute = when (this) {
+        WearMenuDestination.RECORD -> WearRoute.RECORD
+        WearMenuDestination.LIVE_SENSOR -> WearRoute.LIVE
+        WearMenuDestination.SETTINGS -> WearRoute.SETTINGS
+        else -> WearRoute.MENU
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardScreen.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardScreen.kt
@@ -1,0 +1,299 @@
+package com.motionapps.sensorbox.presentation.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumnItemScope
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumnScope
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.SurfaceTransformation
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.TransformationSpec
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
+import com.motionapps.sensorbox.R
+import com.motionapps.sensorbox.domain.sensors.WearSensorDescriptor
+import com.motionapps.sensorbox.presentation.menu.WearMenuScreen
+import com.motionapps.sensorbox.presentation.menu.WearMenuState
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+
+@Composable
+fun WearDashboardScreen(
+    state: WearDashboardState,
+    chartModelProducer: CartesianChartModelProducer,
+    accept: (WearDashboardIntent) -> Unit,
+) {
+    when (state.route) {
+        WearRoute.MENU -> WearMenuRoute(accept)
+        WearRoute.RECORD -> WearRecordScreen(state, accept)
+        WearRoute.LIVE -> WearLiveScreen(state, chartModelProducer, accept)
+        WearRoute.SETTINGS -> WearSettingsScreen(state, accept)
+        WearRoute.ACTIVE -> WearActiveScreen(state.preferences.keepWearDisplayOn, accept)
+    }
+}
+
+@Composable
+private fun WearMenuRoute(accept: (WearDashboardIntent) -> Unit) {
+    WearMenuScreen(WearMenuState()) { accept(WearDashboardIntent.Open(it)) }
+}
+
+@Composable
+private fun WearRecordScreen(state: WearDashboardState, accept: (WearDashboardIntent) -> Unit) {
+    val listState = rememberTransformingLazyColumnState()
+    val transformation = rememberTransformationSpec()
+    AppScaffold {
+        ScreenScaffold(scrollState = listState) { padding ->
+            TransformingLazyColumn(state = listState, contentPadding = padding) {
+                item { WearHeader(stringResource(R.string.activity_record), transformation) }
+                state.sensors.forEach { sensor ->
+                    item {
+                        WearSensorButton(sensor, sensor.type in state.selectedSensorIds, transformation) {
+                            accept(WearDashboardIntent.ToggleSensor(sensor.type))
+                        }
+                    }
+                }
+                item {
+                    WearChoiceButton(stringResource(R.string.gps), state.includesGps, transformation) {
+                        accept(WearDashboardIntent.ToggleGps)
+                    }
+                }
+                state.message?.let { message -> item { WearHeader(wearMessageText(message), transformation) } }
+                item {
+                    WearActionButton(stringResource(R.string.start_recording), transformation) {
+                        accept(WearDashboardIntent.StartMeasurement)
+                    }
+                }
+                item { WearBackButton(transformation, accept) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WearLiveScreen(
+    state: WearDashboardState,
+    chartModelProducer: CartesianChartModelProducer,
+    accept: (WearDashboardIntent) -> Unit,
+) {
+    val selected = state.sensors.firstOrNull { it.type == state.liveSensorType }
+    if (selected == null) {
+        WearSensorPicker(state.sensors, accept)
+        return
+    }
+    AppScaffold {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 18.dp, vertical = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(selected.name)
+            Text(state.latestValue?.let { "%.2f".format(it) } ?: stringResource(R.string.waiting))
+            CartesianChartHost(
+                chart = rememberCartesianChart(rememberLineCartesianLayer()),
+                modelProducer = chartModelProducer,
+                modifier = Modifier.fillMaxWidth().height(92.dp),
+            )
+            Button(
+                label = { Text(stringResource(R.string.back)) },
+                onClick = { accept(WearDashboardIntent.Back) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WearSensorPicker(sensors: List<WearSensorDescriptor>, accept: (WearDashboardIntent) -> Unit) {
+    val listState = rememberTransformingLazyColumnState()
+    val transformation = rememberTransformationSpec()
+    AppScaffold {
+        ScreenScaffold(scrollState = listState) { padding ->
+            TransformingLazyColumn(state = listState, contentPadding = padding) {
+                item { WearHeader(stringResource(R.string.activity_view_sensor), transformation) }
+                sensors.forEach { sensor ->
+                    item {
+                        WearActionButton(sensor.name, transformation) {
+                            accept(WearDashboardIntent.ObserveSensor(sensor.type))
+                        }
+                    }
+                }
+                item { WearBackButton(transformation, accept) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WearSettingsScreen(state: WearDashboardState, accept: (WearDashboardIntent) -> Unit) {
+    val listState = rememberTransformingLazyColumnState()
+    val transformation = rememberTransformationSpec()
+    AppScaffold {
+        ScreenScaffold(scrollState = listState) { padding ->
+            TransformingLazyColumn(state = listState, contentPadding = padding) {
+                item { WearHeader(stringResource(R.string.activity_settings), transformation) }
+                preferenceItems(state, transformation, accept)
+                item {
+                    WearActionButton(
+                        stringResource(if (state.isSyncing) R.string.syncing else R.string.sync_recordings),
+                        transformation,
+                    ) {
+                        accept(WearDashboardIntent.SyncMeasurements)
+                    }
+                }
+                state.message?.let { message -> item { WearHeader(wearMessageText(message), transformation) } }
+                item { WearBackButton(transformation, accept) }
+            }
+        }
+    }
+}
+
+private fun TransformingLazyColumnScope.preferenceItems(
+    state: WearDashboardState,
+    transformation: TransformationSpec,
+    accept: (WearDashboardIntent) -> Unit,
+) {
+    listOf(
+        R.string.sampling_fastest,
+        R.string.sampling_game,
+        R.string.sampling_ui,
+        R.string.sampling_normal,
+    ).forEachIndexed { index, label ->
+        item {
+            WearChoiceButton(stringResource(label), state.preferences.sensorSamplingPeriod == index, transformation) {
+                accept(WearDashboardIntent.SetSamplingPeriod(index))
+            }
+        }
+    }
+    item {
+        WearChoiceButton(
+            stringResource(R.string.stop_on_low_battery),
+            state.preferences.restrictMeasurementOnLowBattery,
+            transformation,
+        ) {
+            accept(WearDashboardIntent.ToggleBatteryRestriction)
+        }
+    }
+    item {
+        WearChoiceButton(stringResource(R.string.wake_lock), state.preferences.useWakeLock, transformation) {
+            accept(WearDashboardIntent.ToggleWakeLock)
+        }
+    }
+    item {
+        WearChoiceButton(
+            stringResource(R.string.keep_display_on),
+            state.preferences.keepWearDisplayOn,
+            transformation,
+        ) {
+            accept(WearDashboardIntent.ToggleDisplay)
+        }
+    }
+}
+
+@Composable
+private fun WearActiveScreen(keepDisplayOn: Boolean, accept: (WearDashboardIntent) -> Unit) {
+    AppScaffold {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(22.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(stringResource(R.string.recording))
+            Text(stringResource(if (keepDisplayOn) R.string.display_stays_on else R.string.display_may_sleep))
+            Button(
+                label = { Text(stringResource(R.string.stop_and_save)) },
+                onClick = { accept(WearDashboardIntent.StopMeasurement) },
+                modifier = Modifier.fillMaxWidth().fillMaxHeight(0.45f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearSensorButton(
+    sensor: WearSensorDescriptor,
+    selected: Boolean,
+    transformation: TransformationSpec,
+    onClick: () -> Unit,
+) = WearChoiceButton(sensor.name, selected, transformation, sensor.vendor, onClick)
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearChoiceButton(
+    label: String,
+    selected: Boolean,
+    transformation: TransformationSpec,
+    detail: String? = null,
+    onClick: () -> Unit,
+) {
+    Button(
+        label = { Text(label) },
+        secondaryLabel = detail?.let { { Text(it) } },
+        icon = { Text(stringResource(if (selected) R.string.selected_symbol else R.string.unselected_symbol)) },
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = label }
+            .transformedHeight(this, transformation),
+        transformation = SurfaceTransformation(transformation),
+    )
+}
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearActionButton(
+    label: String,
+    transformation: TransformationSpec,
+    onClick: () -> Unit,
+) {
+    Button(
+        label = { Text(label) },
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().transformedHeight(this, transformation),
+        transformation = SurfaceTransformation(transformation),
+    )
+}
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearBackButton(
+    transformation: TransformationSpec,
+    accept: (WearDashboardIntent) -> Unit,
+) = WearActionButton(stringResource(R.string.back), transformation) { accept(WearDashboardIntent.Back) }
+
+@Composable
+private fun wearMessageText(message: WearDashboardMessage): String = when (message) {
+    WearDashboardMessage.PickSource -> stringResource(R.string.message_pick_source)
+
+    WearDashboardMessage.PermissionRequired -> stringResource(R.string.message_permission_required)
+
+    WearDashboardMessage.SensorUnavailable -> stringResource(R.string.message_sensor_unavailable)
+
+    WearDashboardMessage.Syncing -> stringResource(R.string.syncing)
+
+    WearDashboardMessage.SyncFailed -> stringResource(R.string.message_sync_failed)
+
+    is WearDashboardMessage.FilesSent ->
+        pluralStringResource(R.plurals.message_files_sent, message.count, message.count)
+}
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearHeader(label: String, transformation: TransformationSpec) {
+    ListHeader(
+        modifier = Modifier.fillMaxWidth().transformedHeight(this, transformation),
+        transformation = SurfaceTransformation(transformation),
+    ) { Text(label) }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardViewModel.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardViewModel.kt
@@ -1,0 +1,202 @@
+package com.motionapps.sensorbox.presentation.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.motionapps.sensorbox.core.error.AppError
+import com.motionapps.sensorbox.core.preferences.AppPreferencesIntent
+import com.motionapps.sensorbox.core.preferences.AppPreferencesRepository
+import com.motionapps.sensorbox.domain.measurement.WearMeasurementControlUseCase
+import com.motionapps.sensorbox.domain.measurement.WearMeasurementPermissionUseCase
+import com.motionapps.sensorbox.domain.sensors.GetWearSensorsUseCase
+import com.motionapps.sensorbox.domain.sensors.ObserveSensorValuesUseCase
+import com.motionapps.sensorbox.domain.sync.SyncWearMeasurementsUseCase
+import com.motionapps.sensorbox.presentation.menu.WearMenuDestination
+import com.motionapps.sensorservices.session.MeasurementSessionState
+import com.motionapps.sensorservices.session.MeasurementSessionStore
+import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class WearDashboardViewModel @Inject constructor(
+    getSensors: GetWearSensorsUseCase,
+    private val observeSensorValues: ObserveSensorValuesUseCase,
+    private val permissionUseCase: WearMeasurementPermissionUseCase,
+    private val measurementControl: WearMeasurementControlUseCase,
+    private val preferencesRepository: AppPreferencesRepository,
+    private val sessionStore: MeasurementSessionStore,
+    private val syncMeasurements: SyncWearMeasurementsUseCase,
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(WearDashboardState(sensors = getSensors()))
+    private val mutableEffects = Channel<WearDashboardEffect>(Channel.BUFFERED)
+    private var sensorJob: Job? = null
+    private var pendingStart = false
+
+    val state = mutableState.asStateFlow()
+    val effects = mutableEffects.receiveAsFlow()
+    val chartModelProducer = CartesianChartModelProducer()
+
+    init {
+        observePreferences()
+        observeSession()
+    }
+
+    fun accept(intent: WearDashboardIntent) {
+        mutableState.value = WearDashboardReducer.reduce(mutableState.value, intent)
+        when (intent) {
+            is WearDashboardIntent.Open -> handleDestination(intent.destination)
+            WearDashboardIntent.StartMeasurement -> requestMeasurementStart()
+            is WearDashboardIntent.PermissionsResolved -> handlePermissionResult(intent.granted)
+            WearDashboardIntent.StopMeasurement -> measurementControl.stop().showFailure()
+            is WearDashboardIntent.ObserveSensor -> observeLiveSensor(intent.sensorType)
+            is WearDashboardIntent.SetSamplingPeriod -> setSamplingPeriod(intent.index)
+            WearDashboardIntent.ToggleBatteryRestriction -> toggleBatteryRestriction()
+            WearDashboardIntent.ToggleWakeLock -> toggleWakeLock()
+            WearDashboardIntent.ToggleDisplay -> toggleDisplay()
+            WearDashboardIntent.SyncMeasurements -> startSync()
+            else -> Unit
+        }
+    }
+
+    private fun handleDestination(destination: WearMenuDestination) {
+        when (destination) {
+            WearMenuDestination.PHONE_INFO -> mutableEffects.trySend(WearDashboardEffect.OpenPhone)
+            WearMenuDestination.PRIVACY, WearMenuDestination.TERMS -> openUrl(destination)
+            else -> Unit
+        }
+    }
+
+    private fun openUrl(destination: WearMenuDestination) {
+        mutableEffects.trySend(WearDashboardEffect.OpenUrl(destination))
+    }
+
+    private fun requestMeasurementStart() {
+        val state = mutableState.value
+        if (state.selectedSensorIds.isEmpty() && !state.includesGps) {
+            mutableState.value = state.copy(message = WearDashboardMessage.PickSource)
+            return
+        }
+        val includesHeartRate = state.sensors.any {
+            it.type in state.selectedSensorIds && it.isHeartRate
+        }
+        val missing = permissionUseCase(state.includesGps, includesHeartRate)
+        if (missing.isEmpty()) startMeasurement() else requestPermissions(missing)
+    }
+
+    private fun requestPermissions(permissions: Set<String>) {
+        pendingStart = true
+        mutableEffects.trySend(WearDashboardEffect.RequestPermissions(permissions))
+    }
+
+    private fun handlePermissionResult(granted: Boolean) {
+        if (granted && pendingStart) startMeasurement()
+        if (!granted) mutableState.value = mutableState.value.copy(message = WearDashboardMessage.PermissionRequired)
+        pendingStart = false
+    }
+
+    private fun startMeasurement() {
+        val state = mutableState.value
+        measurementControl.start(state.selectedSensorIds, state.includesGps, state.preferences).showFailure()
+    }
+
+    private fun observeLiveSensor(sensorType: Int) {
+        sensorJob?.cancel()
+        sensorJob = viewModelScope.launch {
+            observeSensorValues(sensorType)
+                .catch { error ->
+                    AppError.from(AppError.Kind.MEASUREMENT, "Observe live sensor", error)
+                    showSensorError()
+                }
+                .collect(::publishSensorValue)
+        }
+    }
+
+    private suspend fun publishSensorValue(value: Float) {
+        val samples = sampleBuffer + value
+        sampleBuffer = samples.takeLast(MAX_SAMPLES)
+        mutableState.value = mutableState.value.copy(latestValue = value, message = null)
+        chartModelProducer.runTransaction { lineModel { series(sampleBuffer) } }
+    }
+
+    private fun showSensorError() {
+        mutableState.value = mutableState.value.copy(message = WearDashboardMessage.SensorUnavailable)
+    }
+
+    private fun observePreferences() = viewModelScope.launch {
+        preferencesRepository.preferences.collect { result ->
+            result.fold(
+                onSuccess = { preferences ->
+                    mutableState.value = mutableState.value.copy(preferences = preferences)
+                },
+                onFailure = { showOperationFailure() },
+            )
+        }
+    }
+
+    private fun observeSession() = viewModelScope.launch {
+        sessionStore.state.collect { session ->
+            val route = if (session is MeasurementSessionState.Running) WearRoute.ACTIVE else null
+            if (route != null) mutableState.value = mutableState.value.copy(route = route)
+            if (session is MeasurementSessionState.Idle && mutableState.value.route == WearRoute.ACTIVE) {
+                mutableState.value = mutableState.value.copy(route = WearRoute.MENU)
+            }
+        }
+    }
+
+    private fun updatePreference(intent: AppPreferencesIntent) {
+        viewModelScope.launch { preferencesRepository.dispatch(intent).showFailure() }
+    }
+
+    private fun setSamplingPeriod(index: Int) = updatePreference(
+        AppPreferencesIntent.SetSensorSamplingPeriod(index),
+    )
+
+    private fun toggleBatteryRestriction() = updatePreference(
+        AppPreferencesIntent.SetLowBatteryRestriction(
+            !mutableState.value.preferences.restrictMeasurementOnLowBattery,
+        ),
+    )
+
+    private fun toggleWakeLock() = updatePreference(
+        AppPreferencesIntent.SetWakeLock(!mutableState.value.preferences.useWakeLock),
+    )
+
+    private fun toggleDisplay() = updatePreference(
+        AppPreferencesIntent.SetKeepWearDisplayOn(!mutableState.value.preferences.keepWearDisplayOn),
+    )
+
+    private fun startSync() {
+        if (mutableState.value.isSyncing) return
+        mutableState.value = mutableState.value.copy(isSyncing = true, message = WearDashboardMessage.Syncing)
+        viewModelScope.launch {
+            val result = syncMeasurements()
+            val message = result.fold(
+                onSuccess = WearDashboardMessage::FilesSent,
+                onFailure = { WearDashboardMessage.SyncFailed },
+            )
+            mutableState.value = mutableState.value.copy(isSyncing = false, message = message)
+        }
+    }
+
+    private var sampleBuffer: List<Float> = emptyList()
+
+    private fun Result<*>.showFailure() {
+        if (isFailure) showOperationFailure()
+    }
+
+    private fun showOperationFailure() {
+        mutableState.value = mutableState.value.copy(message = WearDashboardMessage.SyncFailed)
+    }
+
+    private companion object {
+        const val MAX_SAMPLES = 60
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuContract.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuContract.kt
@@ -1,0 +1,35 @@
+package com.motionapps.sensorbox.presentation.menu
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.motionapps.sensorbox.R
+
+enum class WearMenuDestination(@StringRes val labelResource: Int, @DrawableRes val iconResource: Int) {
+    RECORD(R.string.activity_record, R.drawable.ic_archive),
+    LIVE_SENSOR(R.string.activity_view_sensor, R.drawable.ic_poll),
+    PHONE_INFO(R.string.activity_info_phone, R.drawable.ic_info),
+    SETTINGS(R.string.activity_settings, R.drawable.ic_more_horiz_24dp_wht),
+    PRIVACY(R.string.activity_privacy_policy, R.drawable.ic_incognito),
+    TERMS(R.string.activity_terms_of_use, R.drawable.ic_policy),
+}
+
+data class WearMenuState(val destinations: List<WearMenuDestination> = WearMenuDestination.entries)
+
+sealed interface WearMenuIntent {
+    data class SelectDestination(val destination: WearMenuDestination) : WearMenuIntent
+}
+
+sealed interface WearMenuEffect {
+    data class OpenDestination(val destination: WearMenuDestination) : WearMenuEffect
+}
+
+data class WearMenuNext(val state: WearMenuState, val effect: WearMenuEffect? = null)
+
+object WearMenuReducer {
+    fun reduce(state: WearMenuState, intent: WearMenuIntent): WearMenuNext = when (intent) {
+        is WearMenuIntent.SelectDestination -> WearMenuNext(
+            state = state,
+            effect = WearMenuEffect.OpenDestination(intent.destination),
+        )
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuScreen.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuScreen.kt
@@ -1,0 +1,75 @@
+package com.motionapps.sensorbox.presentation.menu
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumnItemScope
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.SurfaceTransformation
+import androidx.wear.compose.material3.Text
+import androidx.wear.compose.material3.lazy.TransformationSpec
+import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+import androidx.wear.compose.material3.lazy.transformedHeight
+import com.motionapps.sensorbox.R
+
+@Composable
+fun WearMenuScreen(state: WearMenuState, onDestinationSelected: (WearMenuDestination) -> Unit) {
+    val columnState = rememberTransformingLazyColumnState()
+    val transformationSpec = rememberTransformationSpec()
+    AppScaffold {
+        ScreenScaffold(scrollState = columnState) { contentPadding ->
+            TransformingLazyColumn(
+                state = columnState,
+                contentPadding = contentPadding,
+            ) {
+                item {
+                    ListHeader(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .transformedHeight(this, transformationSpec),
+                        transformation = SurfaceTransformation(transformationSpec),
+                    ) {
+                        Text(stringResource(R.string.app_name))
+                    }
+                }
+                state.destinations.forEach { destination ->
+                    item { WearMenuButton(destination, transformationSpec, onDestinationSelected) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TransformingLazyColumnItemScope.WearMenuButton(
+    destination: WearMenuDestination,
+    transformationSpec: TransformationSpec,
+    onDestinationSelected: (WearMenuDestination) -> Unit,
+) {
+    val label = stringResource(destination.labelResource)
+    Button(
+        label = { Text(label) },
+        icon = {
+            Image(
+                painter = painterResource(destination.iconResource),
+                contentDescription = null,
+            )
+        },
+        onClick = { onDestinationSelected(destination) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = label }
+            .transformedHeight(this, transformationSpec),
+        transformation = SurfaceTransformation(transformationSpec),
+    )
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuViewModel.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/menu/WearMenuViewModel.kt
@@ -1,0 +1,25 @@
+package com.motionapps.sensorbox.presentation.menu
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class WearMenuViewModel @Inject constructor() : ViewModel() {
+    private val mutableState = MutableStateFlow(WearMenuState())
+    private val mutableEffects = Channel<WearMenuEffect>(Channel.BUFFERED)
+
+    val state: StateFlow<WearMenuState> = mutableState.asStateFlow()
+    val effects = mutableEffects.receiveAsFlow()
+
+    fun accept(intent: WearMenuIntent) {
+        val next = WearMenuReducer.reduce(mutableState.value, intent)
+        mutableState.value = next.state
+        next.effect?.let(mutableEffects::trySend)
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchContract.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchContract.kt
@@ -1,0 +1,56 @@
+package com.motionapps.sensorbox.presentation.phonelaunch
+
+enum class PhoneLaunchStatus {
+    IDLE,
+    PHONE_UNAVAILABLE,
+    LAUNCHING,
+    SENT,
+    FAILED,
+}
+
+data class PhoneLaunchState(
+    val isPhoneConnected: Boolean = false,
+    val status: PhoneLaunchStatus = PhoneLaunchStatus.IDLE,
+)
+
+sealed interface PhoneLaunchIntent {
+    data object LaunchRequested : PhoneLaunchIntent
+
+    data class ConnectionChanged(val isConnected: Boolean) : PhoneLaunchIntent
+
+    data class LaunchCompleted(val succeeded: Boolean) : PhoneLaunchIntent
+}
+
+sealed interface PhoneLaunchEffect {
+    data object SendLaunchMessage : PhoneLaunchEffect
+}
+
+data class PhoneLaunchNext(val state: PhoneLaunchState, val effect: PhoneLaunchEffect? = null)
+
+object PhoneLaunchReducer {
+    fun reduce(state: PhoneLaunchState, intent: PhoneLaunchIntent): PhoneLaunchNext = when (intent) {
+        is PhoneLaunchIntent.ConnectionChanged -> connectionChanged(state, intent.isConnected)
+        is PhoneLaunchIntent.LaunchCompleted -> launchCompleted(state, intent.succeeded)
+        PhoneLaunchIntent.LaunchRequested -> launchRequested(state)
+    }
+
+    private fun connectionChanged(state: PhoneLaunchState, isConnected: Boolean) = PhoneLaunchNext(
+        state.copy(
+            isPhoneConnected = isConnected,
+            status = if (isConnected) PhoneLaunchStatus.IDLE else PhoneLaunchStatus.PHONE_UNAVAILABLE,
+        ),
+    )
+
+    private fun launchCompleted(state: PhoneLaunchState, succeeded: Boolean) = PhoneLaunchNext(
+        state.copy(status = if (succeeded) PhoneLaunchStatus.SENT else PhoneLaunchStatus.FAILED),
+    )
+
+    private fun launchRequested(state: PhoneLaunchState): PhoneLaunchNext = if (state.isPhoneConnected) {
+        PhoneLaunchNext(
+            state = state.copy(status = PhoneLaunchStatus.LAUNCHING),
+            effect = PhoneLaunchEffect.SendLaunchMessage,
+        )
+    } else {
+        PhoneLaunchNext(state.copy(status = PhoneLaunchStatus.PHONE_UNAVAILABLE))
+    }
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchScreen.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchScreen.kt
@@ -1,0 +1,46 @@
+package com.motionapps.sensorbox.presentation.phonelaunch
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import com.motionapps.sensorbox.R
+
+@Composable
+fun PhoneLaunchScreen(state: PhoneLaunchState, onLaunchPhone: () -> Unit) {
+    AppScaffold {
+        ScreenScaffold {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(stringResource(statusText(state.status)))
+                Button(
+                    label = { Text(stringResource(R.string.open_phone)) },
+                    onClick = onLaunchPhone,
+                    enabled = state.isPhoneConnected && state.status != PhoneLaunchStatus.LAUNCHING,
+                )
+            }
+        }
+    }
+}
+
+private fun statusText(status: PhoneLaunchStatus): Int = when (status) {
+    PhoneLaunchStatus.IDLE -> R.string.phone_ready
+    PhoneLaunchStatus.PHONE_UNAVAILABLE -> R.string.norespond
+    PhoneLaunchStatus.LAUNCHING -> R.string.open_module
+    PhoneLaunchStatus.SENT -> R.string.phone_opened
+    PhoneLaunchStatus.FAILED -> R.string.error_toast
+}

--- a/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchViewModel.kt
+++ b/wear/src/main/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchViewModel.kt
@@ -1,0 +1,52 @@
+package com.motionapps.sensorbox.presentation.phonelaunch
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.motionapps.sensorbox.core.error.suspendFlatMap
+import com.motionapps.wearoslib.WearOsConstants.PHONE_APP_CAPABILITY
+import com.motionapps.wearoslib.WearOsConstants.PHONE_MESSAGE_PATH
+import com.motionapps.wearoslib.connectivity.ObserveWearCapabilityUseCase
+import com.motionapps.wearoslib.connectivity.SendWearMessageUseCase
+import com.motionapps.wearoslib.connectivity.WearConnection
+import com.motionapps.wearoslib.protocol.WearCommand
+import com.motionapps.wearoslib.protocol.WearCommandCodec
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PhoneLaunchViewModel @Inject constructor(
+    private val observeWearCapability: ObserveWearCapabilityUseCase,
+    private val sendWearMessage: SendWearMessageUseCase,
+) : ViewModel() {
+    private val mutableState = MutableStateFlow(PhoneLaunchState())
+    val state: StateFlow<PhoneLaunchState> = mutableState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            observeWearCapability(PHONE_APP_CAPABILITY).collect { connection ->
+                accept(PhoneLaunchIntent.ConnectionChanged(connection is WearConnection.Connected))
+            }
+        }
+    }
+
+    fun accept(intent: PhoneLaunchIntent) {
+        val next = PhoneLaunchReducer.reduce(mutableState.value, intent)
+        mutableState.value = next.state
+        if (next.effect == PhoneLaunchEffect.SendLaunchMessage) {
+            sendLaunchMessage()
+        }
+    }
+
+    private fun sendLaunchMessage() {
+        viewModelScope.launch {
+            val result = WearCommandCodec.encode(WearCommand.LaunchPhone).suspendFlatMap { payload ->
+                sendWearMessage(PHONE_APP_CAPABILITY, PHONE_MESSAGE_PATH, payload)
+            }
+            accept(PhoneLaunchIntent.LaunchCompleted(result.isSuccess))
+        }
+    }
+}

--- a/wear/src/test/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardReducerTest.kt
+++ b/wear/src/test/java/com/motionapps/sensorbox/presentation/dashboard/WearDashboardReducerTest.kt
@@ -1,0 +1,43 @@
+package com.motionapps.sensorbox.presentation.dashboard
+
+import com.motionapps.sensorbox.core.testing.AppPreferencesFixtures
+import com.motionapps.sensorbox.presentation.menu.WearMenuDestination
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WearDashboardReducerTest {
+    @Test
+    fun `Given menu When record is opened Then record route is selected`() {
+        val givenState = WearDashboardState()
+
+        val actual = WearDashboardReducer.reduce(
+            givenState,
+            WearDashboardIntent.Open(WearMenuDestination.RECORD),
+        )
+
+        assertEquals(WearRoute.RECORD, actual.route)
+    }
+
+    @Test
+    fun `Given no selected sensor When toggled Then sensor becomes selected`() {
+        val givenState = WearDashboardState(
+            preferences = AppPreferencesFixtures.preferences(gpsIntervalSeconds = 30),
+        )
+
+        val actual = WearDashboardReducer.reduce(givenState, WearDashboardIntent.ToggleSensor(21))
+
+        assertTrue(21 in actual.selectedSensorIds)
+        assertEquals(30, actual.preferences.gpsIntervalSeconds)
+    }
+
+    @Test
+    fun `Given live picker When sensor is chosen Then chart route retains sensor`() {
+        val givenState = WearDashboardState(route = WearRoute.LIVE)
+
+        val actual = WearDashboardReducer.reduce(givenState, WearDashboardIntent.ObserveSensor(4))
+
+        assertEquals(WearRoute.LIVE, actual.route)
+        assertEquals(4, actual.liveSensorType)
+    }
+}

--- a/wear/src/test/java/com/motionapps/sensorbox/presentation/menu/WearMenuReducerTest.kt
+++ b/wear/src/test/java/com/motionapps/sensorbox/presentation/menu/WearMenuReducerTest.kt
@@ -1,0 +1,22 @@
+package com.motionapps.sensorbox.presentation.menu
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WearMenuReducerTest {
+    @Test
+    fun `Given the menu When record is selected Then opening record is requested`() {
+        val givenState = WearMenuState()
+
+        val whenNext = WearMenuReducer.reduce(
+            givenState,
+            WearMenuIntent.SelectDestination(WearMenuDestination.RECORD),
+        )
+
+        assertEquals(givenState, whenNext.state)
+        assertEquals(
+            WearMenuEffect.OpenDestination(WearMenuDestination.RECORD),
+            whenNext.effect,
+        )
+    }
+}

--- a/wear/src/test/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchReducerTest.kt
+++ b/wear/src/test/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchReducerTest.kt
@@ -1,0 +1,27 @@
+package com.motionapps.sensorbox.presentation.phonelaunch
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PhoneLaunchReducerTest {
+    @Test
+    fun `Given a connected phone When launch is requested Then message sending starts`() {
+        val givenState = PhoneLaunchState(isPhoneConnected = true)
+
+        val whenNext = PhoneLaunchReducer.reduce(givenState, PhoneLaunchIntent.LaunchRequested)
+
+        assertEquals(PhoneLaunchStatus.LAUNCHING, whenNext.state.status)
+        assertEquals(PhoneLaunchEffect.SendLaunchMessage, whenNext.effect)
+    }
+
+    @Test
+    fun `Given no connected phone When launch is requested Then unavailable is shown`() {
+        val givenState = PhoneLaunchState(isPhoneConnected = false)
+
+        val whenNext = PhoneLaunchReducer.reduce(givenState, PhoneLaunchIntent.LaunchRequested)
+
+        assertEquals(PhoneLaunchStatus.PHONE_UNAVAILABLE, whenNext.state.status)
+        assertNull(whenNext.effect)
+    }
+}

--- a/wear/src/test/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchViewModelTest.kt
+++ b/wear/src/test/java/com/motionapps/sensorbox/presentation/phonelaunch/PhoneLaunchViewModelTest.kt
@@ -1,0 +1,47 @@
+package com.motionapps.sensorbox.presentation.phonelaunch
+
+import com.motionapps.sensorbox.testing.MainDispatcherRule
+import com.motionapps.wearoslib.connectivity.FakeWearConnectionRepository
+import com.motionapps.wearoslib.connectivity.ObserveWearCapabilityUseCase
+import com.motionapps.wearoslib.connectivity.SendWearMessageUseCase
+import com.motionapps.wearoslib.connectivity.WearConnection
+import com.motionapps.wearoslib.connectivity.WearNode
+import com.motionapps.wearoslib.protocol.WearCommand
+import com.motionapps.wearoslib.protocol.WearCommandCodec
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PhoneLaunchViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `Given connected phone When launch is requested Then versioned command is sent`() = runTest {
+        val repository = connectedRepository()
+        val viewModel = createViewModel(repository)
+        advanceUntilIdle()
+
+        viewModel.accept(PhoneLaunchIntent.LaunchRequested)
+        advanceUntilIdle()
+
+        assertEquals(PhoneLaunchStatus.SENT, viewModel.state.value.status)
+        assertEquals(
+            WearCommand.LaunchPhone,
+            WearCommandCodec.decode(repository.sentMessages.single().payload).getOrThrow(),
+        )
+    }
+
+    private fun connectedRepository() = FakeWearConnectionRepository(
+        WearConnection.Connected(WearNode("phone", "Phone", isNearby = true)),
+    )
+
+    private fun createViewModel(repository: FakeWearConnectionRepository) = PhoneLaunchViewModel(
+        ObserveWearCapabilityUseCase(repository),
+        SendWearMessageUseCase(repository),
+    )
+}

--- a/wear/src/test/java/com/motionapps/sensorbox/testing/MainDispatcherRule.kt
+++ b/wear/src/test/java/com/motionapps/sensorbox/testing/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.motionapps.sensorbox.testing
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(val dispatcher: TestDispatcher = StandardTestDispatcher()) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
Architecture stack 16 of 39.

Base: `architecture/15-phone-resources`
Head: `architecture/16-wear-compose`
Changed lines in this layer: 1276.

This layer contains the domain-focused change named in the title. Review the numbered stack in order. This PR targets the branch immediately before it, so GitHub shows only this layer.

Stack navigation: previous #70; next #72.